### PR TITLE
(CLOUD-278) Example acceptance testing mechanism for vSphere module

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
+  gem "mustache"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
+    mustache (1.0.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)
@@ -155,6 +156,7 @@ DEPENDENCIES
   fog
   guard-rake
   metadata-json-lint
+  mustache
   pry
   pry-rescue
   pry-stack_explorer

--- a/lib/puppet/provider/vsphere_machine/fog.rb
+++ b/lib/puppet/provider/vsphere_machine/fog.rb
@@ -74,7 +74,10 @@ Puppet::Type.type(:vsphere_machine).provide(:fog) do
     Puppet.info("Deleting machine #{name}")
     machine = client.servers.find_all { |server| server.name == name }
     fail "Found more than one machine named #{name}" if machine.count != 1
-    machine.first.stop
+    unless machine.first.power_state == 'poweredOff'
+      machine.first.stop
+      machine.first.wait_for { power_state == 'poweredOff' }
+    end
     machine.first.destroy
     @property_hash[:ensure] = :absent
   end

--- a/spec/acceptance/fixtures/machine.pp.tmpl
+++ b/spec/acceptance/fixtures/machine.pp.tmpl
@@ -1,0 +1,11 @@
+vsphere_machine { '{{name}}':
+  ensure   => {{ensure}},
+  template => '{{template_path}}',
+  memory   => {{memory}},
+  cpus     => {{cpus}},
+  vdc      => '{{vdc}}',
+  folder   => '{{folder}}',
+  {{#optional}}
+  {{k}}    => '{{v}}',
+  {{/optional}}
+}

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper_acceptance'
+require 'securerandom'
+
+describe 'vsphere_machine' do
+
+  before(:all) do
+    @client = VsphereHelper.new
+    @template = 'machine.pp.tmpl'
+  end
+
+  def get_machine(name)
+    machines = @client.get_machines(name)
+    expect(machines.count).to eq(1)
+    machines.first
+  end
+
+  describe 'should be able to create a machine' do
+
+    before(:all) do
+      @name = SecureRandom.hex(8)
+      @config = {
+        :name => @name,
+        :ensure => 'present',
+        :memory => 1024,
+        :cpus => 1,
+        :folder => 'eng',
+        :vdc => 'opdx1',
+        :template_path => '/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
+      }
+      PuppetManifest.new(@template, @config).apply
+      @machine = get_machine(@name)
+    end
+
+    after(:all) do
+      new_config = @config.update({:ensure => 'absent'})
+      PuppetManifest.new(@template, new_config).apply
+    end
+
+    it 'with the specified name' do
+      expect(@machine.name).to eq(@name)
+    end
+
+    context 'when looked for using puppet resource' do
+      before(:all) do
+        @result = TestExecutor.puppet_resource('vsphere_machine', {:name => @name}, '--modulepath ../')
+      end
+
+      it 'should not return an error' do
+        expect(@result.stderr).not_to match(/\b/)
+      end
+
+      it 'should report the correct ensure value' do
+        regex = /(ensure)(\s*)(=>)(\s*)('present')/
+        expect(@result.stdout).to match(regex)
+      end
+    end
+
+  end
+
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,147 @@
+require 'mustache'
+require 'open3'
+require 'fog'
+
+class PuppetManifest < Mustache
+
+  def initialize(file, config)
+    @template_file = File.join(Dir.getwd, 'spec', 'acceptance', 'fixtures', file)
+    config.each do |key, value|
+      config_value = self.class.to_generalized_data(value)
+      instance_variable_set("@#{key}".to_sym, config_value)
+      self.class.send(:attr_accessor, key)
+    end
+  end
+
+  def apply
+    manifest = self.render.gsub("\n", '')
+    cmd = "bundle exec puppet apply --detailed-exitcodes -e \"#{manifest}\" --modulepath ../"
+    result = { output: [], exit_status: nil }
+
+    Open3.popen2e(cmd) do |stdin, stdout_err, wait_thr|
+      while line = stdout_err.gets
+        result[:output].push(line)
+        puts line
+      end
+      result[:exit_status] = wait_thr.value
+    end
+
+    result
+  end
+
+  def self.to_generalized_data(val)
+    case val
+    when Hash
+      to_generalized_hash_list(val)
+    when Array
+      to_generalized_array_list(val)
+    else
+      val
+    end
+  end
+
+  # returns an array of :k =>, :v => hashes given a Hash
+  # { :a => 'b', :c => 'd' } -> [{:k => 'a', :v => 'b'}, {:k => 'c', :v => 'd'}]
+  def self.to_generalized_hash_list(hash)
+    hash.map { |k, v| { :k => k, :v => v }}
+  end
+
+  # necessary to build like [{ :values => Array }] rather than [[]] when there
+  # are nested hashes, for the sake of Mustache being able to render
+  # otherwise, simply return the item
+  def self.to_generalized_array_list(arr)
+    arr.map do |item|
+      if item.class == Hash
+        {
+          :values => to_generalized_hash_list(item)
+        }
+      else
+        item
+      end
+    end
+  end
+
+end
+
+class VsphereHelper
+
+  def initialize
+    server = ENV['VSPHERE_SERVER']
+    user = ENV['VSPHERE_USER']
+    password = ENV['VSPHERE_PASSWORD']
+    hash = ENV['VSPHERE_HASH']
+    version = '5.5'
+    secure = false
+    credentials = {
+      :provider => 'vsphere',
+      :vsphere_username => user ,
+      :vsphere_password => password,
+      :vsphere_server => server,
+      :vsphere_ssl  => secure,
+      :vsphere_expected_pubkey_hash => hash,
+      :vsphere_rev  => version
+    }
+    @client = Fog::Compute.new(credentials)
+  end
+
+  def get_machines(name)
+    @client.servers.find_all { |server| server.name == name }
+  end
+
+end
+
+class TestExecutor
+
+  def self.shell(cmd)
+    Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+      @out = read_stream(stdout)
+      @error = read_stream(stderr)
+      @code = /(exit)(\s)(\d+)/.match(wait_thr.value.to_s)[3]
+    end
+    TestExecutor::Response.new(@out, @error, @code, cmd)
+  end
+
+  def self.read_stream(stream)
+    result = String.new
+    while line = stream.gets
+      result << line if line.class == String
+      puts line
+    end
+    result
+  end
+
+  # build and apply complex puppet resource commands
+  # the arguement resource is the type of the resource
+  # the opts hash must include a key 'name'
+  def self.puppet_resource(resource, opts = {}, command_flags = '')
+    raise 'A name for the resource must be specified' unless opts[:name]
+    cmd = "puppet resource #{resource} "
+    options = String.new
+    opts.each do |k,v|
+      if k.to_s == 'name'
+        @name = v
+      else
+        options << "#{k.to_s}=#{v.to_s} "
+      end
+    end
+    cmd << "#{@name} "
+    cmd << options
+    cmd << " #{command_flags}"
+    # apply the command
+    response = shell(cmd)
+    response
+  end
+
+end
+
+class TestExecutor::Response
+  attr_reader :stdout , :stderr, :exit_code, :command
+
+  def initialize(standard_out, standard_error, exit, cmd)
+    @stdout = standard_out
+    @stderr = standard_error
+    @exit_code = exit
+    @command = cmd
+  end
+
+end


### PR DESCRIPTION
This is based on the same pattern as used in the AWS module.

I've submitted this against this repo just for ease of showing a running example. If we're happy with this we might have moved this repo for the real thing, but this should demonstrate intent and be enough to discuss and accept or not the story.

Note that these tests actually passes, but aren't intended to be complete (you could add lots more assertions). They are intended to:
- demonstrate injecting information into dynamic Puppet templates
- running Puppet code as part of the test run
- writing assertions against the resulting machine
- work with both puppet apply and puppet resource
