### PR TITLE
(CLOUD-282) Support creating nested VMs

### DIFF
--- a/lib/puppet_x/puppetlabs/vsphere.rb
+++ b/lib/puppet_x/puppetlabs/vsphere.rb
@@ -53,7 +53,7 @@ module PuppetX
       def initialize(path)
         @name = path.split('/')[-1]
         @datacenter = path.split('/')[1]
-        @folder = path.split('/')[3...-1].join('/')
+        @folder = path.split('/')[3...-1]
         @local_path = "/#{path.split('/')[3..-1].join('/')}"
       end
     end

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -93,4 +93,31 @@ describe 'vsphere_machine' do
 
   end
 
+  describe 'should be able to create a machine with a nested folder' do
+
+    before(:all) do
+      @name = SecureRandom.hex(8)
+      @path = "/opdx1/vm/eng/test/test/#{@name}"
+      @config = {
+        :name          => @path,
+        :ensure        => 'present',
+        :compute       => 'general1',
+        :template_path => '/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
+        :memory        => 512,
+        :cpus          => 1,
+      }
+      PuppetManifest.new(@template, @config).apply
+      @machine = @client.get_machine(@path)
+    end
+
+    after(:all) do
+      new_config = @config.update({:ensure => 'absent'})
+      PuppetManifest.new(@template, new_config).apply
+    end
+
+    it 'with the specified name' do
+      expect(@machine.name).to eq(@name)
+    end
+
+  end
 end

--- a/spec/unit/vsphere_machine_spec.rb
+++ b/spec/unit/vsphere_machine_spec.rb
@@ -13,11 +13,18 @@ describe PuppetX::Puppetlabs::Vsphere::Machine do
   end
 
   it 'should extract a folder from a path' do
-    expect(machine.folder).to eq('eng')
+    expect(machine.folder).to eq(['eng'])
   end
 
   it 'should extract a local path from a path' do
     expect(machine.local_path).to eq('/eng/551425a5fc66efaf')
+  end
+
+  context 'with a deeply nested folder' do
+    let(:machine) { PuppetX::Puppetlabs::Vsphere::Machine.new('/opdx1/vm/eng/test/sample/551425a5fc66efaf') }
+    it 'should extract a folder from a path' do
+      expect(machine.folder).to eq(['eng', 'test', 'sample'])
+    end
   end
 
 end

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,4 +1,4 @@
-vsphere_machine { '/opdx1/vm/eng/garethr-test':
+vsphere_machine { '/opdx1/vm/eng/garethr/garethr-test':
   ensure   => stopped,
   template => '/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
   compute  => 'general1',


### PR DESCRIPTION
Machines may be created in nested folders, and those folders may not
exist at the point of creation. This change supports that expected
behaviour.
