### PR TITLE
(Cloud-291) Allows creation of a VM from existing VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Managing vSphere machines using the Puppet DSL.
 This module allows for describing a vSphere machine using the Puppet
 DSL:
 
+*To create a new VM from a Template:*
 ~~~
 vsphere_machine { '/opdx1/vm/eng/sample':
   ensure   => present,
@@ -76,6 +77,15 @@ vsphere_machine { '/opdx1/vm/eng/sample':
   compute  => 'general1',
   memory   => 1024,
   cpus     => 1,
+}
+~~~
+
+*To create a new VM from an existing VM:*
+~~~
+vsphere_machine { '/opdx1/vm/eng/sample':
+  ensure         => present,
+  source_machine => '/opdx1/vm/eng/source',
+  compute        => 'general1',
 }
 ~~~
 
@@ -144,16 +154,22 @@ identifier.
 machine.
 
 #####`template`
-*Required* The path within the specificed datacenter to the template to
-base the new virtual machine on.
+The path within the specified datacenter to the template to
+base the new virtual machine on. Specifying a template or a source_machine
+is required when specifying `ensure => 'present'`.
+
+#####`source_machine`
+The path within the specified datacenter to the virtual machine to
+base the new virtual machine on. Specifying a template or a source_machine
+is required when specifying `ensure => 'present'`.
 
 #####`memory`
 The amount of memory to allocate to the new machine. Defaults to the
-same as the template.
+same as the template or source machine.
 
 #####`cpus`
 The number of CPUs to allocate to the new machine. Defaults to the
-same as the template.
+same as the template or source machine.
 
 #####`cpu_reservation`
 *Read Only* How many of the CPUs allocated are reserved just for this

--- a/lib/puppet/type/vsphere_machine.rb
+++ b/lib/puppet/type/vsphere_machine.rb
@@ -3,6 +3,10 @@ require_relative '../../puppet_x/puppetlabs/property/read_only'
 Puppet::Type.newtype(:vsphere_machine) do
   @doc = 'Type representing a virtual machine in VMWare vSphere.'
 
+  validate do
+    fail "Cannot specify both template and source_machine paths" if self[:template] && self[:source_machine]
+  end
+
   newproperty(:ensure) do
     newvalue(:present) do
       provider.create unless provider.exists?
@@ -50,6 +54,13 @@ Puppet::Type.newtype(:vsphere_machine) do
     end
   end
 
+  newparam(:source_machine) do
+    desc 'The path to an existing machine to use as the base for the new machine.'
+    validate do |value|
+      fail 'Virtual machine path should be a String' unless value.is_a? String
+    end
+  end
+
   newproperty(:memory) do
     desc 'The amount of memory in MB to use for the machine.'
     def insync?(is)
@@ -94,6 +105,10 @@ Puppet::Type.newtype(:vsphere_machine) do
     newproperty(property, :parent => PuppetX::Property::ReadOnly) do
       desc "Information related to #{value} from the vSphere API."
     end
+  end
+
+  autorequire(:vsphere_machine) do
+    self[:source_machine]
   end
 
 end

--- a/spec/acceptance/fixtures/clone_vm.pp.tmpl
+++ b/spec/acceptance/fixtures/clone_vm.pp.tmpl
@@ -1,0 +1,8 @@
+vsphere_machine { '{{name}}':
+  ensure         => {{ensure}},
+  compute        => '{{compute}}',
+  source_machine => '{{source_machine}}',
+  {{#optional}}
+  {{k}}          => '{{v}}',
+  {{/optional}}
+}

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -8,7 +8,6 @@ describe 'vsphere_machine' do
     @template = 'machine.pp.tmpl'
   end
 
-
   describe 'should be able to create a machine' do
 
     before(:all) do
@@ -135,5 +134,60 @@ describe 'vsphere_machine' do
       expect(@machine.name).to eq(@name)
     end
 
+  end
+
+  describe 'should be able to create a machine from another machine' do
+    before(:all) do
+      @name = SecureRandom.hex(8)
+
+      @source_path = "/opdx1/vm/eng/test/#{@name}_source"
+      @source_config = {
+        :name          => @source_path,
+        :ensure        => 'present',
+        :compute       => 'general1',
+        :template_path => '/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
+        :memory        => 512,
+        :cpus          => 1,
+      }
+      PuppetManifest.new(@template, @source_config).apply
+      @source_machine = @client.get_machine(@source_path)
+
+      @clone_template = 'clone_vm.pp.tmpl'
+      @target_path = "/opdx1/vm/eng/test/clones/#{@name}_target"
+      source_vm_path = @source_path.clone
+      @target_config = {
+        :name           => @target_path,
+        :ensure         => 'present',
+        :compute        => 'general1',
+        :source_machine => source_vm_path,
+      }
+      PuppetManifest.new(@clone_template, @target_config).apply
+      @target_machine = @client.get_machine(@target_path)
+    end
+
+    after(:all) do
+      new_source_config = @source_config.update({:ensure => 'absent'})
+      PuppetManifest.new(@template, new_source_config).apply
+
+      new_target_config = @target_config.update({:ensure => 'absent'})
+      PuppetManifest.new(@clone_template, new_target_config).apply
+    end
+
+    it 'should have same config as source vm' do
+      [
+        :cpuReservation,
+        :guestFullName,
+        :guestId,
+        :installBootRequired,
+        :memoryReservation,
+        :memorySizeMB,
+        :numCpu,
+        :numEthernetCards,
+        :numVirtualDisks,
+        :template,
+      ].each do |property|
+        expect(@source_machine.summary.config[property]).to eq(@target_machine.summary.config[property])
+      end
+    end
   end
 end

--- a/spec/unit/type/vsphere_machine_spec.rb
+++ b/spec/unit/type/vsphere_machine_spec.rb
@@ -8,6 +8,7 @@ describe type_class do
     [
       :name,
       :template,
+      :source_machine,
     ]
   end
 
@@ -144,6 +145,12 @@ describe type_class do
       expect(@machine.property(:ensure).insync?(:running)).to be true
     end
 
+  end
+
+  it 'should prohibit source_machine and template to be set together' do
+    expect {
+      type_class.new({name: 'sample', source_machine: 'something', template: 'something'})
+    }.to raise_error(Puppet::Error, /Cannot specify both template and source_machine/)
   end
 
 end


### PR DESCRIPTION
This is a modified version of https://github.com/puppetlabs/puppetlabs-vsphere/pull/8 with a few suggested changes. I went ahead and made a PR rather than just leaving comments as it was the end of the sprint today. The changes are:
- change `source_vm` to `source_machine`. The type is `vsphere_machine` and I think for the public interface we should use one of machine or vm, otherwise it gets confusing
- changed the expected path for the source_machine to be the full path, and fed it through the `Vsphere::Machine class`. This allows us to support the autorequire function, so if you define two machines, one a clone of the other in the same manifest Puppet will get the ordering right. It's also a more consistent user interface (in hindsight we might want to change the template path once we get to the template stories next week)
- added unit tests for the type around the new param and the validation rules

Apart from that (basically all about the user interface) the original PR worked for me.
