### PR TITLE
(CLOUD-281) Add support for managing templates as well as machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,25 +67,14 @@ Managing vSphere machines using the Puppet DSL.
 ## Getting started with vSphere
 
 This module allows for describing a vSphere machine using the Puppet
-DSL:
+DSL. To create a new machine from a template or other machine:
 
-*To create a new VM from a Template:*
 ~~~
 vsphere_machine { '/opdx1/vm/eng/sample':
-  ensure   => present,
-  template => '/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
-  compute  => 'general1',
-  memory   => 1024,
-  cpus     => 1,
-}
-~~~
-
-*To create a new VM from an existing VM:*
-~~~
-vsphere_machine { '/opdx1/vm/eng/sample':
-  ensure         => present,
-  source_machine => '/opdx1/vm/eng/source',
-  compute        => 'general1',
+  ensure => present,
+  source => '/opdx1/vm/eng/source',
+  memory => 1024,
+  cpus   => 1,
 }
 ~~~
 
@@ -112,6 +101,7 @@ vsphere_machine { '/opdx1/vm/eng/sample':
   snapshot_disabled           => 'false',
   snapshot_locked             => 'false',
   snapshot_power_off_behavior => 'powerOff',
+  template                    => 'false',
   tools_installer_mounted     => 'false',
   uuid                        => '4218419b-3b98-18ca-e77f-93b567dda463',
 }
@@ -152,33 +142,35 @@ can specify which datacenter you are managing using the
 
 ### Parameters
 
-#### Type: vSphere_machine
+#### Type: vsphere_machine
 
 #####`ensure`
-Specifies the basic state of the resource. Valid values are 'present', 'running', stopped', 'unregistered', and 'absent'.
+Specifies the basic state of the resource. Valid values are 'present', 'running',
+stopped', 'unregistered', and 'absent'. Defaults to 'present'.
 * 'present', 'running': ensure that the VM is up and running. If the VM is not
   there yet, a new one will be created as specified by the other properties.
 * 'stopped': ensure that the VM is created, but not running.
-* 'unregistered': ensure that the VM is not under active management in vSphere. This will keep the vmx/vhd files around.
+* 'unregistered': ensure that the VM is not under active management in vSphere.
+  This will keep the vmx/vhd files around.
 * 'absent': ensure that the VM and all its files are removed.
+If the machine is a template then only present, absent and unregistered
+are valid states.
 
 #####`name`
 *Required* The full path for the machine, including the datacenter
 identifier.
 
 #####`compute`
-*Required* The name of the computre resource in which to launch the
-machine.
+The name of the compute resource in which to launch the
+machine. Defaults to the default resource pool for the datacenter.
+
+#####`source`
+The path within the specified datacenter to the virtual machine or
+template to base the new virtual machine on. Specifying a source
+is required when specifying `ensure => 'present'`.
 
 #####`template`
-The path within the specified datacenter to the template to
-base the new virtual machine on. Specifying a template or a source_machine
-is required when specifying `ensure => 'present'`.
-
-#####`source_machine`
-The path within the specified datacenter to the virtual machine to
-base the new virtual machine on. Specifying a template or a source_machine
-is required when specifying `ensure => 'present'`.
+Whether or not the machine is a template. Defaults to false.
 
 #####`memory`
 The amount of memory to allocate to the new machine. Defaults to the

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ exclude_paths = [
 Rake::Task[:lint].clear
 
 PuppetLint.configuration.relative = true
+PuppetLint.configuration.disable_80chars
 PuppetLint.configuration.disable_class_inherits_from_params_class
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint::RakeTask.new :lint do |config|

--- a/spec/acceptance/fixtures/clone_vm.pp.tmpl
+++ b/spec/acceptance/fixtures/clone_vm.pp.tmpl
@@ -1,8 +1,0 @@
-vsphere_machine { '{{name}}':
-  ensure         => {{ensure}},
-  compute        => '{{compute}}',
-  source_machine => '{{source_machine}}',
-  {{#optional}}
-  {{k}}          => '{{v}}',
-  {{/optional}}
-}

--- a/spec/acceptance/fixtures/machine.pp.tmpl
+++ b/spec/acceptance/fixtures/machine.pp.tmpl
@@ -1,10 +1,7 @@
 vsphere_machine { '{{name}}':
-  ensure   => {{ensure}},
-  template => '{{template_path}}',
-  compute  => '{{compute}}',
-  memory   => {{memory}},
-  cpus     => {{cpus}},
+  ensure  => {{ensure}},
+  source  => '{{source}}',
   {{#optional}}
-  {{k}}    => '{{v}}',
+  {{k}}   => '{{v}}',
   {{/optional}}
 }

--- a/spec/acceptance/machine_delete_spec.rb
+++ b/spec/acceptance/machine_delete_spec.rb
@@ -8,15 +8,14 @@ shared_context 'a running vm' do
     @name = "CLOUD-#{SecureRandom.hex(8)}"
     @path = "/opdx1/vm/eng/#{@name}"
     @config = {
-      :name          => @path,
-      :compute       => 'general1',
-      :template_path => '/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
-      :memory        => 512,
-      :cpus          => 2,
+      :name    => @path,
+      :source  => '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
     }
     datacenter = @client.datacenter
-    template = datacenter.find_vm(@config[:template_path])
-    pool = datacenter.find_compute_resource(@config[:compute]).resourcePool
+    path = @config[:source]
+    path.slice!('/opdx1/vm')
+    template = datacenter.find_vm(path)
+    pool = datacenter.hostFolder.children.first.resourcePool
     relocate_spec = RbVmomi::VIM.VirtualMachineRelocateSpec(:pool => pool)
     clone_spec = RbVmomi::VIM.VirtualMachineCloneSpec(
       :location => relocate_spec,

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -11,15 +11,17 @@ describe 'vsphere_machine' do
   describe 'should be able to create a machine' do
 
     before(:all) do
-      @name = SecureRandom.hex(8)
-      @path = "/opdx1/vm/eng/#{@name}"
+      @name = "CLOUD-#{SecureRandom.hex(8)}"
+      @path = "/opdx1/vm/eng/test/#{@name}"
       @config = {
-        :name          => @path,
-        :ensure        => 'present',
-        :compute       => 'general1',
-        :template_path => '/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
-        :memory        => 512,
-        :cpus          => 2,
+        :name    => @path,
+        :ensure  => 'present',
+        :source  => '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
+        :optional => {
+          :memory  => 512,
+          :cpus    => 2,
+          :compute => 'general1',
+        }
       }
       PuppetManifest.new(@template, @config).apply
       @machine = @client.get_machine(@path)
@@ -35,15 +37,15 @@ describe 'vsphere_machine' do
     end
 
     it 'attached to the specified compute resource' do
-      expect(@machine.resourcePool.parent.name).to eq(@config[:compute])
+      expect(@machine.resourcePool.parent.name).to eq(@config[:optional][:compute])
     end
 
     it 'with the specified memory setting' do
-      expect(@machine.summary.config.memorySizeMB).to eq(@config[:memory])
+      expect(@machine.summary.config.memorySizeMB).to eq(@config[:optional][:memory])
     end
 
     it 'with the specified cpu setting' do
-      expect(@machine.summary.config.numCpu).to eq(@config[:cpus])
+      expect(@machine.summary.config.numCpu).to eq(@config[:optional][:cpus])
     end
 
     it 'and should not fail to be applied multiple times' do
@@ -53,7 +55,8 @@ describe 'vsphere_machine' do
 
     [:memory, :cpus].each do |read_only|
       it "when trying to set read-only property #{read_only}" do
-        new_config = @config.dup.update({read_only => 4})
+        new_config = Marshal.load(Marshal.dump(@config))
+        new_config[:optional].update({read_only => 4})
         success = PuppetManifest.new(@template, new_config).apply[:exit_status].success?
         expect(success).to eq(false)
       end
@@ -74,17 +77,17 @@ describe 'vsphere_machine' do
       end
 
       it 'should report the correct memory value' do
-        regex = /(memory)(\s*)(=>)(\s*)('#{@config[:memory]}')/
+        regex = /(memory)(\s*)(=>)(\s*)('#{@config[:optional][:memory]}')/
         expect(@result.stdout).to match(regex)
       end
 
       it 'should report the correct compute value' do
-        regex = /(compute)(\s*)(=>)(\s*)('#{@config[:compute]}')/
+        regex = /(compute)(\s*)(=>)(\s*)('#{@config[:optional][:compute]}')/
         expect(@result.stdout).to match(regex)
       end
 
       it 'should report the correct cpu value' do
-        regex = /(cpus)(\s*)(=>)(\s*)('#{@config[:cpus]}')/
+        regex = /(cpus)(\s*)(=>)(\s*)('#{@config[:optional][:cpus]}')/
         expect(@result.stdout).to match(regex)
       end
 
@@ -101,8 +104,8 @@ describe 'vsphere_machine' do
         'instance_uuid',
       ].each do |read_only_property|
         it "#{read_only_property} is reported" do
-            regex = /(#{read_only_property})(\s*)(=>)(\s*)/
-            expect(@result.stdout).to match(regex)
+          regex = /(#{read_only_property})(\s*)(=>)(\s*)/
+          expect(@result.stdout).to match(regex)
         end
       end
 
@@ -110,18 +113,20 @@ describe 'vsphere_machine' do
 
   end
 
-  describe 'should be able to create a machine with a nested folder' do
+  describe 'should be able to create a machine within a nested folder' do
 
     before(:all) do
-      @name = SecureRandom.hex(8)
+      @name = "CLOUD-#{SecureRandom.hex(8)}"
       @path = "/opdx1/vm/eng/test/test/#{@name}"
       @config = {
-        :name          => @path,
-        :ensure        => 'present',
-        :compute       => 'general1',
-        :template_path => '/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
-        :memory        => 512,
-        :cpus          => 1,
+        :name    => @path,
+        :ensure  => 'present',
+        :source  => '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
+        :optional => {
+          :compute => 'general1',
+          :memory  => 512,
+          :cpus    => 1,
+        }
       }
       PuppetManifest.new(@template, @config).apply
       @machine = @client.get_machine(@path)
@@ -140,30 +145,30 @@ describe 'vsphere_machine' do
 
   describe 'should be able to create a machine from another machine' do
     before(:all) do
-      @name = SecureRandom.hex(8)
+      @name = "CLOUD-#{SecureRandom.hex(8)}"
 
-      @source_path = "/opdx1/vm/eng/test/#{@name}_source"
+      @source_path = "/opdx1/vm/eng/test/#{@name}-source"
       @source_config = {
-        :name          => @source_path,
-        :ensure        => 'present',
-        :compute       => 'general1',
-        :template_path => '/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
-        :memory        => 512,
-        :cpus          => 1,
+        :name    => @source_path,
+        :ensure  => 'present',
+        :source  => '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
+        :optional => {
+          :compute => 'general1',
+          :memory  => 512,
+          :cpus    => 1,
+        }
       }
       PuppetManifest.new(@template, @source_config).apply
       @source_machine = @client.get_machine(@source_path)
 
-      @clone_template = 'clone_vm.pp.tmpl'
-      @target_path = "/opdx1/vm/eng/test/clones/#{@name}_target"
+      @target_path = "/opdx1/vm/eng/test/#{@name}-target"
       source_vm_path = @source_path.clone
       @target_config = {
-        :name           => @target_path,
-        :ensure         => 'present',
-        :compute        => 'general1',
-        :source_machine => source_vm_path,
+        :name   => @target_path,
+        :ensure => 'present',
+        :source => source_vm_path,
       }
-      PuppetManifest.new(@clone_template, @target_config).apply
+      PuppetManifest.new(@template, @target_config).apply
       @target_machine = @client.get_machine(@target_path)
     end
 
@@ -172,7 +177,7 @@ describe 'vsphere_machine' do
       PuppetManifest.new(@template, new_source_config).apply
 
       new_target_config = @target_config.update({:ensure => 'absent'})
-      PuppetManifest.new(@clone_template, new_target_config).apply
+      PuppetManifest.new(@template, new_target_config).apply
     end
 
     it 'should have same config as source vm' do
@@ -192,4 +197,92 @@ describe 'vsphere_machine' do
       end
     end
   end
+
+  describe 'should be able to create a template from another template' do
+
+    before(:all) do
+      @name = "CLOUD-#{SecureRandom.hex(8)}"
+      @path = "/opdx1/vm/eng/test/#{@name}"
+      @config = {
+        :name     => @path,
+        :ensure   => 'present',
+        :source   => '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
+        :optional => {
+          :template => true,
+        }
+      }
+      PuppetManifest.new(@template, @config).apply
+      @machine = @client.get_machine(@path)
+    end
+
+    after(:all) do
+      new_config = @config.update({:ensure => 'absent'})
+      PuppetManifest.new(@template, new_config).apply
+    end
+
+    it 'with the specified name' do
+      expect(@machine.name).to eq(@name)
+    end
+
+    it 'which is really a template' do
+      expect(@machine.summary.config.template).to eq(true)
+    end
+  end
+
+  describe 'should be able to create a template from another machine' do
+    before(:all) do
+      @name = "CLOUD-#{SecureRandom.hex(8)}"
+
+      @source_path = "/opdx1/vm/eng/test/#{@name}-source"
+      @source_config = {
+        :name    => @source_path,
+        :ensure  => 'present',
+        :source  => '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
+      }
+      PuppetManifest.new(@template, @source_config).apply
+      @source_machine = @client.get_machine(@source_path)
+
+      @target_path = "/opdx1/vm/eng/test/#{@name}-target"
+      source_vm_path = @source_path.clone
+      @target_config = {
+        :name   => @target_path,
+        :ensure => 'present',
+        :source => source_vm_path,
+        :optional => {
+          :template => true,
+        }
+      }
+      PuppetManifest.new(@template, @target_config).apply
+      @target_machine = @client.get_machine(@target_path)
+    end
+
+    after(:all) do
+      new_source_config = @source_config.update({:ensure => 'absent'})
+      PuppetManifest.new(@template, new_source_config).apply
+
+      new_target_config = @target_config.update({:ensure => 'absent'})
+      PuppetManifest.new(@template, new_target_config).apply
+    end
+
+    it 'which is definitely a template' do
+      expect(@target_machine.summary.config.template).to eq(true)
+    end
+
+    it 'should have same config as source vm' do
+      [
+        :cpuReservation,
+        :guestFullName,
+        :guestId,
+        :installBootRequired,
+        :memoryReservation,
+        :memorySizeMB,
+        :numCpu,
+        :numEthernetCards,
+        :numVirtualDisks,
+      ].each do |property|
+        expect(@source_machine.summary.config[property]).to eq(@target_machine.summary.config[property])
+      end
+    end
+  end
+
 end

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,7 +1,12 @@
 vsphere_machine { '/opdx1/vm/eng/garethr/garethr-test':
-  ensure   => stopped,
-  template => '/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
-  compute  => 'general1',
-  memory   => 1024,
-  cpus     => 1,
+  ensure => absent,
+  source => '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
+  memory => 1024,
+  cpus   => 2,
+
+}
+vsphere_machine { '/opdx1/vm/eng/garethr/garethr-template':
+  ensure   => present,
+  source   => '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
+  template => true,
 }


### PR DESCRIPTION
Rather than add a additional type for templates this follows the API and
makes whether a machine is a template or not a boolean flag. This has a few
advantages:
- Less code (no new type)
- Simpler interface (no new type)
- Faster (because we can prefetch all machines in one go rather than
  having to make a request per type)
- Avoid path clashes (templates and machines are really the same thing,
  so can't occupy the same path)
- Removes the need for source_machine and template params, collapsing
  down to just source

While adjusting the acceptance tests to match the new interface I also:
- Set them all to create machines in the test folder
- Named all the machines CLOUD-\* as per the delete spec
- Removes the need for the extra fixtures template

We should look at rationalising the acceptance tests with some helpers
but that was out of scope for this PR, which is already on the large
size.
