### PR TITLE
(MAINT) Ensure we support all cloud provisioner attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ vsphere_machine { '/opdx1/vm/eng/sample':
   compute                     => 'general1',
   cpu_reservation             => '0',
   cpus                        => '1',
+  guest_ip                    => '10.32.99.41',
+  hostname                    => 'debian',
+  instance_uuid               => '501870f2-f891-879f-2bb7-f87023789959',
   memory                      => '1024',
   memory_reservation          => '0',
   number_ethernet_cards       => '1',
@@ -110,6 +113,7 @@ vsphere_machine { '/opdx1/vm/eng/sample':
   snapshot_locked             => 'false',
   snapshot_power_off_behavior => 'powerOff',
   tools_installer_mounted     => 'false',
+  uuid                        => '4218419b-3b98-18ca-e77f-93b567dda463',
 }
 ~~~
 
@@ -211,3 +215,15 @@ machine.
 #####`snapshot_power_off_behaviour`
 *Read Only* Whether to revert to a snapshot when the machine is powered
 off.
+
+#####`uuid`
+*Read Only* the BIOS unique identifier
+
+#####`instance_uuid`
+*Read Only* unique identifier for the vSphere instance
+
+#####`hostname`
+*Read Only* the hostname of the machine is one is assigned
+
+#####`guest_ip`
+*Read Only* the IP address assigned to the machine

--- a/lib/puppet/provider/vsphere_machine/rbvmomi.rb
+++ b/lib/puppet/provider/vsphere_machine/rbvmomi.rb
@@ -32,6 +32,7 @@ Puppet::Type.type(:vsphere_machine).provide(:rbvmomi, :parent => PuppetX::Puppet
     resource_pool = machine.resourcePool
     compute = resource_pool ? resource_pool.parent.name : nil
     state = machine.runtime.powerState  == 'poweredOn' ? :running : :stopped
+    hostname = machine.summary.guest.hostName
     {
       name: "/#{name}",
       memory: machine.summary.config.memorySizeMB,
@@ -46,6 +47,10 @@ Puppet::Type.type(:vsphere_machine).provide(:rbvmomi, :parent => PuppetX::Puppet
       snapshot_disabled: machine.config.flags.snapshotDisabled,
       snapshot_locked: machine.config.flags.snapshotLocked,
       snapshot_power_off_behavior: machine.config.flags.snapshotPowerOffBehavior,
+      uuid: machine.summary.config.uuid,
+      instance_uuid: machine.summary.config.instanceUuid,
+      guest_ip: machine.guest_ip,
+      hostname: hostname == '(none)' ? nil : hostname,
     }
   end
 

--- a/lib/puppet/type/vsphere_machine.rb
+++ b/lib/puppet/type/vsphere_machine.rb
@@ -102,6 +102,10 @@ Puppet::Type.newtype(:vsphere_machine) do
     snapshot_disabled: 'snapshotDisabled',
     snapshot_locked: 'snapshotLocked',
     snapshot_power_off_behavior: 'snapshotPowerOffBehavior',
+    guest_ip: 'ipAddress',
+    uuid: 'uuid',
+    instance_uuid: 'instanceUuid',
+    hostname: 'hostName',
   }
 
   read_only_properties.each do |property, value|

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -97,6 +97,8 @@ describe 'vsphere_machine' do
         'snapshot_disabled',
         'snapshot_locked',
         'snapshot_power_off_behavior',
+        'uuid',
+        'instance_uuid',
       ].each do |read_only_property|
         it "#{read_only_property} is reported" do
             regex = /(#{read_only_property})(\s*)(=>)(\s*)/

--- a/spec/unit/type/vsphere_machine_spec.rb
+++ b/spec/unit/type/vsphere_machine_spec.rb
@@ -31,6 +31,10 @@ describe type_class do
       :snapshot_disabled,
       :snapshot_locked,
       :snapshot_power_off_behavior,
+      :uuid,
+      :instance_uuid,
+      :guest_ip,
+      :hostname,
     ]
   end
 
@@ -111,6 +115,10 @@ describe type_class do
     :snapshot_disabled,
     :snapshot_locked,
     :snapshot_power_off_behavior,
+    :uuid,
+    :instance_uuid,
+    :guest_ip,
+    :hostname,
   ].each do |property|
     it "should require #{property} to be read only" do
       expect(type_class).to be_read_only(property)


### PR DESCRIPTION
I noticed that
https://docs.puppetlabs.com/pe/latest/cloudprovisioner_vmware.html
described a few attributes that we didn't display as part of puppet
resource. This commit adds those items along with relevant tests and
docs.
