### PR TITLE
(CLOUD-308) Extends connectivity options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,23 @@ Managing vSphere machines using the Puppet DSL.
 2. Set the following environment variables specific to your vSphere
    installation:
 
+  * Required Settings:
       ~~~
       export VSPHERE_SERVER='your-host'
       export VSPHERE_USER='your-username'
       export VSPHERE_PASSWORD='your-password'
+      ~~~
+
+  * Optional Settings:
+      ~~~
+      # To ignore SSL certificate errors. Defaults to true.
+      export VSPHERE_INSECURE='true or false'
+
+      # Whether to use SSL. Defaults to true.
+      export VSPHERE_SSL='true or false'
+
+      # Sets vSphere server port to connect to. Defaults to 443(SSL) or 80(non-SSL).
+      export VSPHERE_PORT='your-port'
       ~~~
 
 3. Finally install the module with:

--- a/lib/puppet_x/puppetlabs/vsphere.rb
+++ b/lib/puppet_x/puppetlabs/vsphere.rb
@@ -20,11 +20,15 @@ module PuppetX
         end
 
         credentials = {
-          host: ENV['VSPHERE_SERVER'],
-          user: ENV['VSPHERE_USER'],
+          host:     ENV['VSPHERE_SERVER'],
+          user:     ENV['VSPHERE_USER'],
           password: ENV['VSPHERE_PASSWORD'],
-          insecure: true,
         }
+        # Handle optional connection options
+        credentials[:insecure] = ENV['VSPHERE_INSECURE'] || true
+        credentials[:ssl]      = ENV['VSPHERE_SSL'] if ENV['VSPHERE_SSL']
+        credentials[:port]     = ENV['VSPHERE_PORT'] if ENV['VSPHERE_PORT']
+
         RbVmomi::VIM.connect credentials
       end
 


### PR DESCRIPTION
These are the rbvmomi connectivity options I feel comfortable exposing as customizable settings. 

I've tested these manually and verified that we appropriately error if port settings are incorrect and also that defaults are used if no settings are provided.
