### PR TITLE
(CLOUD-313) Support storing credentials in a file as well as ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ spec/fixtures
 .vagrant
 .bundle
 vendor
+.puppet_vsphere.conf

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem 'rbvmomi'
+gem 'hocon'
 
 group :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
     hiera (1.3.4)
       json_pure
     hitimes (1.2.2)
+    hocon (0.0.7)
     interception (0.5)
     json (1.8.2)
     json_pure (1.8.1)
@@ -117,6 +118,7 @@ PLATFORMS
 
 DEPENDENCIES
   guard-rake
+  hocon
   metadata-json-lint
   mustache
   pry

--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ Managing vSphere machines using the Puppet DSL.
 
 1. First install the required dependencies
 
-  * If you're using open source Puppet, the library gem should be installed
+  * If you're using open source Puppet, the vsphere and hocon library should be installed
      into the same Ruby used by Puppet. Install the gem with:
 
-      `gem install rbvmomi`
+      `gem install rbvmomi hocon`
 
   * If you're running Puppet Enterprise, install the gem with this command:
 
-      `/opt/puppet/bin/gem install rbvmomi`
+      `/opt/puppet/bin/gem install rbvmomi hocon`
 
     This allows the gem to be used by the Puppet Enterprise Ruby.
 
   * If you're running [Puppet Server](https://github.com/puppetlabs/puppet-server), you need to make the gem available to JRuby with:
 
-      `/opt/puppet/bin/puppetserver gem install rbvmomi`
+      `/opt/puppet/bin/puppetserver gem install rbvmomi hocon`
 
     Once the gems are installed, restart Puppet Server.
 
@@ -71,6 +71,40 @@ Managing vSphere machines using the Puppet DSL.
       # Sets vSphere server port to connect to. Defaults to 443(SSL) or 80(non-SSL).
       export VSPHERE_PORT='your-port'
       ~~~
+
+   Alternatively you can provide the information in a configuration
+file. This should be stored as `vsphere.conf` in the relevant
+[confdir](https://docs.puppetlabs.com/puppet/latest/reference/dirs_confdir.html). This should be:
+
+   * nix Systems: /etc/puppetlabs/puppet
+   * Windows: C:\ProgramData\PuppetLabs\puppet\etc
+   * non-root users: ~/.puppetlabs/etc/puppet
+
+   The file format is:
+
+      ~~~
+      vsphere: {
+        host: your-host
+        user: your-username
+        password: your-password
+      }
+      ~~~
+
+   Or with all the settings:
+
+      ~~~
+      vsphere: {
+        host: your-host
+        user: your-username
+        password: your-password
+        port: your-port
+        insecure: false
+        ssl: false
+      }
+      ~~~
+
+    Note that you can use either the environment variables or the config file. If both are present the environment variables will be used.
+    You cannot have some setting in environment variables and the others in the config file.
 
 3. Finally install the module with:
 
@@ -159,6 +193,8 @@ can specify which datacenter you are managing using the
 `VSPHERE_DATACENTER` environment variable like so:
 
     VSPHERE_DATACENTER=my-datacenter puppet resource vpshere_machine
+
+This can also be set in the config file as `datacenter`.
 
 
 ## Usage

--- a/lib/puppet/feature/hocon.rb
+++ b/lib/puppet/feature/hocon.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:hocon, libs: 'hocon')

--- a/lib/puppet/provider/vsphere_machine/rbvmomi.rb
+++ b/lib/puppet/provider/vsphere_machine/rbvmomi.rb
@@ -4,6 +4,7 @@ require 'puppet_x/puppetlabs/vsphere'
 
 Puppet::Type.type(:vsphere_machine).provide(:rbvmomi, :parent => PuppetX::Puppetlabs::Vsphere) do
   confine feature: :rbvmomi
+  confine feature: :hocon
 
   mk_resource_methods
 

--- a/lib/puppet_x/puppetlabs/vsphere_config.rb
+++ b/lib/puppet_x/puppetlabs/vsphere_config.rb
@@ -1,0 +1,89 @@
+module PuppetX
+  module Puppetlabs
+    class VsphereConfig
+      REQUIRED = {
+        names: [:host, :user, :password],
+        envs: ['VSPHERE_SERVER', 'VSPHERE_USER', 'VSPHERE_PASSWORD'],
+      }
+
+      attr_reader :host, :user, :password, :datacenter, :insecure, :port, :ssl
+
+      def default_config_file
+        Puppet.initialize_settings
+        File.join(Puppet[:confdir], 'vsphere.conf')
+      end
+
+      def initialize(config_file=nil)
+        settings = process_environment_variables || process_config_file(config_file || default_config_file)
+        if settings.nil?
+          raise Puppet::Error, 'You must provide credentials in either environment variables or a config file.'
+        else
+          settings = settings.delete_if { |k, v| v.nil? }
+          missing = REQUIRED[:names] - settings.keys
+          unless missing.empty?
+            message = 'To use this module you must provide the following settings:'
+            missing.each do |var|
+              message += " #{var}"
+            end
+            raise Puppet::Error, message
+          end
+          @host = settings[:host]
+          @user = settings[:user]
+          @password = settings[:password]
+          @datacenter = settings[:datacenter_name]
+          @insecure = settings[:insecure].nil? ? true : settings[:insecure]
+          @ssl = settings[:ssl].nil? ? true : settings[:ssl]
+          @port = settings[:port]
+        end
+      end
+
+      def process_config_file(file_path)
+        file_present = File.file?(file_path)
+        unless file_present
+          nil
+        else
+          begin
+            conf = ::Hocon::ConfigFactory.parse_file(file_path)
+          rescue Hocon::ConfigError::ConfigParseError => e
+            raise Puppet::Error, """Your configuration file at #{file_path} is invalid. The error from the parser is
+#{e.message}"""
+          end
+          vsphere_config = conf.root.unwrapped['vsphere']
+          required = REQUIRED[:names].map { |var| var.to_s }
+          missing = required - vsphere_config.keys
+          if missing.size < required.size
+            {
+              host: vsphere_config['host'],
+              user: vsphere_config['user'],
+              password: vsphere_config['password'],
+              datacenter_name: vsphere_config['datacenter'],
+              insecure: vsphere_config['insecure'],
+              port: vsphere_config['port'],
+              ssl: vsphere_config['ssl'],
+            }
+          else
+            nil
+          end
+        end
+      end
+
+      def process_environment_variables
+        required = REQUIRED[:envs]
+        missing = required - ENV.keys
+        if missing.size < required.size
+          {
+            host: ENV['VSPHERE_SERVER'],
+            user: ENV['VSPHERE_USER'],
+            password: ENV['VSPHERE_PASSWORD'],
+            datacenter_name: ENV['VSPHERE_DATACENTER'],
+            insecure: ENV['VSPHERE_INSECURE'],
+            port: ENV['VSPHERE_PORT'],
+            ssl: ENV['VSPHERE_SSL'],
+          }
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/vsphere_config_spec.rb
+++ b/spec/unit/vsphere_config_spec.rb
@@ -1,0 +1,306 @@
+require 'spec_helper'
+require 'puppet_x/puppetlabs/vsphere_config'
+require 'hocon/config_factory'
+
+def nil_environment_variables
+  ENV.delete('VSPHERE_SERVER')
+  ENV.delete('VSPHERE_USER')
+  ENV.delete('VSPHERE_PASSWORD')
+  ENV.delete('VSPHERE_DATACENTER')
+  ENV.delete('VSPHERE_INSECURE')
+  ENV.delete('VSPHERE_PORT')
+  ENV.delete('VSPHERE_SSL')
+end
+
+def create_config_file(path, config)
+  file_contents = %{
+vsphere: {
+  host: #{config[:host]}
+  user: #{config[:user]}
+  password: #{config[:password]}
+  datacenter: #{config[:datacenter_name]}
+}
+  }
+  File.open(path, 'w') { |f| f.write(file_contents) }
+end
+
+def create_full_config_file(path, config)
+  file_contents = %{
+vsphere: {
+  host: #{config[:host]}
+  user: #{config[:user]}
+  password: #{config[:password]}
+  datacenter: #{config[:datacenter_name]}
+  insecure: #{config[:insecure]}
+  port: #{config[:port]}
+  ssl: #{config[:ssl]}
+}
+  }
+  File.open(path, 'w') { |f| f.write(file_contents) }
+end
+
+def create_incomplete_config_file(path, config)
+  file_contents = %{
+vsphere: {
+  host: #{config[:host]}
+}
+  }
+  File.open(path, 'w') { |f| f.write(file_contents) }
+end
+
+
+describe PuppetX::Puppetlabs::VsphereConfig do
+  let(:config_file_path) { File.join(Dir.pwd, '.puppet_vsphere.conf') }
+
+  context 'with the relevant environment variables set' do
+    let(:config) { PuppetX::Puppetlabs::VsphereConfig.new }
+
+    before(:all) do
+      @config = {
+        host: 'vsphere.example.com',
+        user: 'user',
+        password: 'password',
+        datacenter_name: 'test',
+        port: '8090',
+        ssl: 'false',
+        insecure: 'false',
+      }
+      nil_environment_variables
+      ENV['VSPHERE_SERVER'] = @config[:host]
+      ENV['VSPHERE_USER'] = @config[:user]
+      ENV['VSPHERE_PASSWORD'] = @config[:password]
+      ENV['VSPHERE_DATACENTER'] = @config[:datacenter_name]
+      ENV['VSPHERE_PORT'] = @config[:port]
+      ENV['VSPHERE_SSL'] = @config[:ssl]
+      ENV['VSPHERE_INSECURE'] = @config[:insecure]
+    end
+
+    it 'should return the host from an ENV variable' do
+      expect(config.host).to eq(@config[:host])
+    end
+
+    it 'should return the user from an ENV variable' do
+      expect(config.user).to eq(@config[:user])
+    end
+
+    it 'should return the password from an ENV variable' do
+      expect(config.password).to eq(@config[:password])
+    end
+
+    it 'should return the datacenter from an ENV variable' do
+      expect(config.datacenter).to eq(@config[:datacenter_name])
+    end
+
+    it 'should return the insecure value from an ENV variable' do
+      expect(config.insecure).to eq(@config[:insecure])
+    end
+
+    it 'should return the ssl value from an ENV variable' do
+      expect(config.ssl).to eq(@config[:ssl])
+    end
+
+    it 'should return the port value from an ENV variable' do
+      expect(config.port).to eq(@config[:port])
+    end
+
+    it 'should set the default config file location to confdir' do
+      expect(File.dirname(config.default_config_file)).to eq(Puppet[:confdir])
+    end
+  end
+
+  context 'without the optional datacenter environment variables set' do
+    let(:config) { PuppetX::Puppetlabs::VsphereConfig.new }
+
+    before(:all) do
+      nil_environment_variables
+      ENV['VSPHERE_SERVER'] = 'vsphere.example.com'
+      ENV['VSPHERE_USER'] = 'user'
+      ENV['VSPHERE_PASSWORD'] = 'password'
+    end
+
+    it 'should default datacenter to nil' do
+      expect(config.datacenter).to eq(nil)
+    end
+
+    it 'should default insecure to true' do
+      expect(config.insecure).to eq(true)
+    end
+
+    it 'should default ssl to true' do
+      expect(config.ssl).to eq(true)
+    end
+
+    it 'should default port to nil' do
+      expect(config.port).to be_nil
+    end
+  end
+
+  context 'with no environment variables and a valid config file with all optional properties' do
+    let(:config) { PuppetX::Puppetlabs::VsphereConfig.new(config_file_path) }
+
+    before(:all) do
+      @config = {
+        host: 'vsphere2.example.com',
+        user: 'user2',
+        password: 'password2',
+        datacenter_name: 'test2',
+        ssl: false,
+        insecure: false,
+        port: 8091,
+      }
+      @path = File.join(Dir.pwd, '.puppet_vsphere.conf')
+      create_full_config_file(@path, @config)
+      nil_environment_variables
+    end
+
+    after(:all) do
+      File.delete(@path)
+    end
+
+    it 'should return the host from the config file' do
+      expect(config.host).to eq(@config[:host])
+    end
+
+    it 'should return the user from the config file' do
+      expect(config.user).to eq(@config[:user])
+    end
+
+    it 'should return the password from the config file' do
+      expect(config.password).to eq(@config[:password])
+    end
+
+    it 'should return the datacenter from the config file' do
+      expect(config.datacenter).to eq(@config[:datacenter_name])
+    end
+
+    it 'should return the insecure value from the config file' do
+      expect(config.insecure).to eq(@config[:insecure])
+    end
+
+    it 'should return the ssl value from the config file' do
+      expect(config.ssl).to eq(@config[:ssl])
+    end
+
+    it 'should return the port value from the config file' do
+      expect(config.port).to eq(@config[:port])
+    end
+  end
+
+  context 'with no environment variables and a valid config file present' do
+    let(:config) { PuppetX::Puppetlabs::VsphereConfig.new(config_file_path) }
+
+    before(:all) do
+      @config = {
+        host: 'vsphere2.example.com',
+        user: 'user2',
+        password: 'password2',
+        datacenter_name: 'test2',
+      }
+      @path = File.join(Dir.pwd, '.puppet_vsphere.conf')
+      create_config_file(@path, @config)
+      nil_environment_variables
+    end
+
+    after(:all) do
+      File.delete(@path)
+    end
+
+    it 'should return the host from the config file' do
+      expect(config.host).to eq(@config[:host])
+    end
+
+    it 'should return the user from the config file' do
+      expect(config.user).to eq(@config[:user])
+    end
+
+    it 'should return the password from the config file' do
+      expect(config.password).to eq(@config[:password])
+    end
+
+    it 'should return the datacenter from the config file' do
+      expect(config.datacenter).to eq(@config[:datacenter_name])
+    end
+
+    it 'should default insecure to true' do
+      expect(config.insecure).to eq(true)
+    end
+
+    it 'should default ssl to true' do
+      expect(config.ssl).to eq(true)
+    end
+
+    it 'should default port to nil' do
+      expect(config.port).to be_nil
+    end
+  end
+
+  context 'with no environment variables or config file' do
+    before(:all) do
+      nil_environment_variables
+    end
+
+    it 'should raise a suitable error' do
+      expect {
+        PuppetX::Puppetlabs::VsphereConfig.new
+      }.to raise_error(Puppet::Error, /You must provide credentials in either environment variables or a config file/)
+    end
+  end
+
+  context 'with incomplete configuration in environment variables' do
+    before(:all) do
+      ENV['VSPHERE_SERVER'] = 'vsphere.example.com'
+      ENV['VSPHERE_USER'] = nil
+      ENV['VSPHERE_PASSWORD'] = nil
+    end
+
+    it 'should raise an error about the missing variables' do
+      expect {
+        PuppetX::Puppetlabs::VsphereConfig.new
+      }.to raise_error(Puppet::Error, /To use this module you must provide the following settings: user password/)
+    end
+  end
+
+  context 'with no environment variables and an incomplete config file' do
+    before(:all) do
+      @config = {
+        host: 'vsphere2.example.com',
+      }
+      @path = File.join(Dir.pwd, '.puppet_vsphere.conf')
+      create_incomplete_config_file(@path, @config)
+      nil_environment_variables
+    end
+
+    after(:all) do
+      File.delete(@path)
+    end
+
+    it 'should raise an error about the missing variables' do
+      expect {
+        PuppetX::Puppetlabs::VsphereConfig.new(@path)
+      }.to raise_error(Puppet::Error, /To use this module you must provide the following settings: user password/)
+    end
+  end
+
+  context 'with no environment variables and an invalid config file' do
+    before(:all) do
+      @config = {
+        host: 'vsphere2.example.com',
+        user: nil,
+      }
+      @path = File.join(Dir.pwd, '.puppet_vsphere.conf')
+      create_config_file(@path, @config)
+      nil_environment_variables
+    end
+
+    after(:all) do
+      File.delete(@path)
+    end
+
+    it 'should raise an error about the invalid config file' do
+      expect {
+        PuppetX::Puppetlabs::VsphereConfig.new(config_file_path)
+      }.to raise_error(Puppet::Error, /Your configuration file at .+ is invalid/)
+    end
+  end
+
+end


### PR DESCRIPTION
This commit introduces a HOCON based configuration file for storing
credentials, while retaining the option of using ENV variables.

I've purposefully not added additional acceptance tests for this as at
that level it's just using the new VsphereConfig object, which has a set
of unit tests covering the interface.
