### PR TITLE
(CLOUD-328) Support annotations on virtual machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,9 @@ same as the template or source machine.
 The number of CPUs to allocate to the new machine. Defaults to the
 same as the template or source machine.
 
+####`annotation`
+User provided description of the machine.
+
 #####`extra_config`
 A hash containing [vSphere extraConfig](https://www.vmware.com/support/developer/converter-sdk/conv55_apireference/vim.vm.ConfigInfo.html) settings for the virtual machine. Defaults to undef.
 

--- a/lib/puppet/provider/vsphere_machine/rbvmomi.rb
+++ b/lib/puppet/provider/vsphere_machine/rbvmomi.rb
@@ -57,6 +57,7 @@ Puppet::Type.type(:vsphere_machine).provide(:rbvmomi, :parent => PuppetX::Puppet
       guest_ip: machine.guest_ip,
       hostname: hostname == '(none)' ? nil : hostname,
       extra_config: extra_config,
+      annotation: machine.config.annotation,
     }
   end
 
@@ -94,6 +95,7 @@ Puppet::Type.type(:vsphere_machine).provide(:rbvmomi, :parent => PuppetX::Puppet
     clone_spec.config = RbVmomi::VIM.VirtualMachineConfigSpec(deviceChange: [])
     clone_spec.config.numCPUs = resource[:cpus] if resource[:cpus]
     clone_spec.config.memoryMB = resource[:memory] if resource[:memory]
+    clone_spec.config.annotation = resource[:annotation] if resource[:annotation]
 
     vm.CloneVM_Task(
       :folder => find_or_create_folder(datacenter.vmFolder, instance.folder),
@@ -104,10 +106,11 @@ Puppet::Type.type(:vsphere_machine).provide(:rbvmomi, :parent => PuppetX::Puppet
   end
 
   def flush
-    if ! @property_hash.empty? and @property_hash[:ensure] != :absent 
+    if ! @property_hash.empty? and @property_hash[:ensure] != :absent
       config_spec = RbVmomi::VIM.VirtualMachineConfigSpec
       config_spec.numCPUs = resource[:cpus] if resource[:cpus]
       config_spec.memoryMB = resource[:memory] if resource[:memory]
+      config_spec.annotation = resource[:annotation] if resource[:annotation]
       if resource[:extra_config]
         config_spec.extraConfig = resource[:extra_config].map do |k,v|
           {:key => k, :value => v}

--- a/lib/puppet/type/vsphere_machine.rb
+++ b/lib/puppet/type/vsphere_machine.rb
@@ -92,6 +92,13 @@ Puppet::Type.newtype(:vsphere_machine) do
     end
   end
 
+  newproperty(:annotation) do
+    desc 'A user provided description of the machine.'
+    validate do |value|
+      fail 'Virtual machine annotation should be a String' unless value.is_a? String
+    end
+  end
+
   newproperty(:template) do
     desc 'Whether or not this machine is a template.'
     defaultto :false

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -21,6 +21,7 @@ describe 'vsphere_machine' do
           :memory  => 512,
           :cpus    => 2,
           :compute => 'general1',
+          :annotation => 'some text',
         }
       }
       PuppetManifest.new(@template, @config).apply
@@ -46,6 +47,10 @@ describe 'vsphere_machine' do
 
     it 'with the specified cpu setting' do
       expect(@machine.summary.config.numCpu).to eq(@config[:optional][:cpus])
+    end
+
+    it 'with the specified annotation' do
+      expect(@machine.config.annotation).to eq(@config[:optional][:annotation])
     end
 
     it 'and should not fail to be applied multiple times' do
@@ -291,6 +296,7 @@ describe 'vsphere_machine' do
           :compute => 'general1',
           :cpus    => 1,
           :memory  => 512,
+          :annotation => 'some test',
         }
       }
       PuppetManifest.new(@template, @config).apply
@@ -300,8 +306,9 @@ describe 'vsphere_machine' do
         :name     => @path,
         :ensure   => 'present',
         :optional => {
-          :cpus    => 2,
-          :memory  => 1024,
+          :cpus       => 2,
+          :memory     => 1024,
+          :annotation => 'some other test',
         }
       }
       PuppetManifest.new(@template, @new_config).apply
@@ -330,6 +337,11 @@ describe 'vsphere_machine' do
         expect(@config_after[property]).not_to eq(@config_before[property])
         expect(@config_after[property].to_i).to eq(@config_before[property].to_i * 2)
       end
+    end
+
+    it 'should update the annotation' do
+      expect(@config_before[:annotation]).to eq(@config[:optional][:annotation])
+      expect(@config_after[:annotation]).to eq(@new_config[:optional][:annotation])
     end
 
     after(:all) do

--- a/spec/unit/type/vsphere_machine_spec.rb
+++ b/spec/unit/type/vsphere_machine_spec.rb
@@ -19,6 +19,7 @@ describe type_class do
       :compute,
       :template,
       :extra_config,
+      :annotation,
     ]
   end
 
@@ -61,6 +62,7 @@ describe type_class do
   [
     'name',
     'compute',
+    'annotation',
   ].each do |property|
     it "should require #{property} to be a string" do
       expect(type_class).to require_string_for(property)


### PR DESCRIPTION
Annotations allow for arbitrary user provided metadata. It would be
possible to build interesting filtering features around this in the
future but for the moment just exposing the raw annotations would be
useful - both to people using them already or for people building tools
on top of them.
