### PR TITLE
(CLOUD-339) Simplest possible master/agent test in acceptance tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem 'rbvmomi'
 gem 'hocon'
@@ -15,10 +15,15 @@ group :development do
   gem 'pry'
   gem 'puppet-blacksmith'
   gem 'guard-rake'
-  gem 'pry-rescue'
-  gem 'pry-stack_explorer'
+  #gem 'pry-rescue'
+  #gem 'pry-stack_explorer'
 end
 
 group :acceptance do
   gem 'mustache'
+end
+
+group :integration do
+  gem 'beaker', '~> 2.7'
+  gem 'master_manipulator', '~> 1.0'
 end

--- a/integration/files/manifest.erb
+++ b/integration/files/manifest.erb
@@ -1,0 +1,8 @@
+vsphere_vm { '<%= name_path %>':
+  ensure          => <%= status %>,
+  source          => '<%= source_path %>',
+  resource_pool   => 'general1',
+  memory          => 512,
+  cpus            => 1,
+  template        => '<%= is_template %>',
+}

--- a/integration/files/vcenter_conf.erb
+++ b/integration/files/vcenter_conf.erb
@@ -1,0 +1,5 @@
+vcenter: {
+  host: <%= server %>
+  user: <%= user %>
+  password: <%= password %>
+}

--- a/integration/lib/vsphere_helper.rb
+++ b/integration/lib/vsphere_helper.rb
@@ -1,0 +1,20 @@
+require 'rbvmomi'
+
+# ensure to absent a puppetlabs_machine
+def ensure_absent(host, path, name)
+  on(host, "puppet apply -e \"vsphere_vm { '#{path}/#{name}': ensure => 'absent'}\"")
+end
+
+# Verify VM/template has been successfully created in vCenter
+def is_created?(datacenter, name, type)
+  server  = ENV['VCENTER_SERVER']
+  userid  = ENV['VCENTER_USER']
+  passwd  = ENV['VCENTER_PASSWORD']
+
+  type == "VM" ? (path = '/eng/integration/vm') : (path = '/eng/integration/template')
+
+  vim = RbVmomi::VIM.connect insecure: 'true', host: server, user: userid, password: passwd
+  dc = vim.serviceInstance.find_datacenter(datacenter) or fail "datacenter not found"
+  vm = dc.find_vm("#{path}/#{name}")
+  fail_test "Cannot find the #{type}: #{name}" unless vm
+end

--- a/integration/pre-suite/0_install_pe/00_pe_install.rb
+++ b/integration/pre-suite/0_install_pe/00_pe_install.rb
@@ -1,0 +1,14 @@
+require 'master_manipulator'
+test_name 'Install Puppet Enterprise'
+
+step 'Install PE'
+install_pe
+
+step 'Disable Node Classifier'
+disable_node_classifier(master)
+
+step 'Disable environment caching'
+disable_env_cache(master)
+
+step 'Restart Puppet Server'
+restart_puppet_server(master)

--- a/integration/pre-suite/1_install_vsphere_module/00_install_vsphere_from_staging_forge.rb
+++ b/integration/pre-suite/1_install_vsphere_module/00_install_vsphere_from_staging_forge.rb
@@ -1,0 +1,12 @@
+test_name "QA-1912 - C64678 - Install using 'puppet module install puppetlabs-vsphere' command"
+
+step 'Setting Staging Forge'
+stub_forge_on(master)
+
+step 'Install puppetlabs-vsphere module on master'
+on(master, puppet('module install puppetlabs-vsphere'))
+
+agents.each do |agent|
+  step 'install rbvmomi and hocon gems'
+  on(agent, '/opt/puppet/bin/gem install rbvmomi hocon')
+end

--- a/integration/pre-suite/1_install_vsphere_module/01_set_credentials.rb
+++ b/integration/pre-suite/1_install_vsphere_module/01_set_credentials.rb
@@ -1,0 +1,25 @@
+# This file is only for local testing
+# CI task will have its own VC1 credentials
+require 'erb'
+
+step 'Exporting credentials'
+server    = ENV['VCENTER_SERVER']
+user      = ENV['VCENTER_USER']
+password  = ENV['VCENTER_PASSWORD']
+
+# path       = '/etc/puppetlabs/puppet/vcenter.conf'
+#
+# local_files_root_path     = ENV['FILES'] || 'files'
+# vcenter_conf_template     = File.join(local_files_root_path, 'vcenter_conf.erb')
+# vcenter_conf_erb          = ERB.new(File.read(vcenter_conf_template)).result(binding)
+#
+# step 'add env var to hosts'
+# agents.each do |agent|
+#   create_remote_file(agent, path, vcenter_conf_erb)
+# end
+step 'add env var to hosts'
+agents.each do |agent|
+  agent.add_env_var("VCENTER_SERVER", "#{server}")
+  agent.add_env_var("VCENTER_USER", "#{user}")
+  agent.add_env_var("VCENTER_PASSWORD", "#{password}")
+end

--- a/integration/test_run_scripts/configs/centos-6-x86_64.cfg
+++ b/integration/test_run_scripts/configs/centos-6-x86_64.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  centos-6-x86_64-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-6-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-6-x86_64
+    hypervisor: vcloud
+  centos-6-x86_64-agent:
+    roles:
+      - agent
+    platform: el-6-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-6-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/integration/test_run_scripts/configs/centos-7-x86_64.cfg
+++ b/integration/test_run_scripts/configs/centos-7-x86_64.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  centos-7-x86_64-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+  centos-7-x86_64-agent:
+    roles:
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/integration/test_run_scripts/configs/rhel7m-ubuntua-x86_64.cfg
+++ b/integration/test_run_scripts/configs/rhel7m-ubuntua-x86_64.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+    hypervisor: vcloud
+  agent:
+    roles:
+      - agent
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/integration/test_run_scripts/configs/ubuntum-rhel7a-x86_64.cfg
+++ b/integration/test_run_scripts/configs/ubuntum-rhel7a-x86_64.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+  agent:
+    roles:
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/integration/test_run_scripts/vsphere/vsphere_centos6.sh
+++ b/integration/test_run_scripts/vsphere/vsphere_centos6.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+SCRIPT_PATH=$(pwd)
+BASENAME_CMD="basename ${SCRIPT_PATH}"
+SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
+
+if [ $SCRIPT_BASE_PATH = "vsphere" ]; then
+  cd ../../
+fi
+export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.8.0/
+export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
+
+bundle install --without acceptance development test --path .bundle/gems
+
+bundle exec beaker \
+  --config test_run_scripts/configs/centos-6-x86_64.cfg \
+  --debug \
+  --pre-suite pre-suite \
+  --test tests \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --load-path lib \
+  --preserve-host \
+  --timeout 360
+
+rm -rf .bundle

--- a/integration/test_run_scripts/vsphere/vsphere_centos7.sh
+++ b/integration/test_run_scripts/vsphere/vsphere_centos7.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+SCRIPT_PATH=$(pwd)
+BASENAME_CMD="basename ${SCRIPT_PATH}"
+SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
+
+if [ $SCRIPT_BASE_PATH = "vsphere" ]; then
+  cd ../../
+fi
+export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.8.0/
+export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
+
+bundle install --without acceptance development test --path .bundle/gems
+
+bundle exec beaker \
+  --config test_run_scripts/configs/centos-7-x86_64.cfg \
+  --debug \
+  --pre-suite pre-suite \
+  --test tests \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --load-path lib \
+  --preserve-host \
+  --timeout 360
+
+rm -rf .bundle

--- a/integration/test_run_scripts/vsphere/vsphere_rhel7m_ubuntua.sh
+++ b/integration/test_run_scripts/vsphere/vsphere_rhel7m_ubuntua.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+SCRIPT_PATH=$(pwd)
+BASENAME_CMD="basename ${SCRIPT_PATH}"
+SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
+
+if [ $SCRIPT_BASE_PATH = "vsphere" ]; then
+  cd ../../
+fi
+
+export pe_dist_dir: http://pe-releases.puppetlabs.lan/3.8.0/
+export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
+
+bundle install --without acceptance development test --path .bundle/gems
+
+bundle exec beaker \
+  --config test_run_scripts/configs/rhel7m-ubuntua-x86_64.cfg \
+  --debug \
+  --pre-suite pre-suite \
+  --test tests \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --load-path lib \
+  --preserve-host \
+  --timeout 360
+
+rm -rf .bundle

--- a/integration/test_run_scripts/vsphere/vsphere_ubuntum_rhel7a.sh
+++ b/integration/test_run_scripts/vsphere/vsphere_ubuntum_rhel7a.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+SCRIPT_PATH=$(pwd)
+BASENAME_CMD="basename ${SCRIPT_PATH}"
+SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
+
+if [ $SCRIPT_BASE_PATH = "vsphere" ]; then
+  cd ../../
+fi
+
+export pe_dist_dir: http://pe-releases.puppetlabs.lan/3.8.0/
+export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
+
+bundle install --without acceptance development test --path .bundle/gems
+
+bundle exec beaker \
+  --config test_run_scripts/configs/ubuntum-rhel7a-x86_64.cfg \
+  --debug \
+  --pre-suite pre-suite \
+  --test tests \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --load-path lib \
+  --preserve-host \
+  --timeout 360
+
+rm -rf .bundle

--- a/integration/tests/01_create_vm_from_template.rb
+++ b/integration/tests/01_create_vm_from_template.rb
@@ -1,0 +1,43 @@
+require 'vsphere_helper'
+require 'SecureRandom'
+require 'erb'
+require 'rbvmomi'
+require 'master_manipulator'
+
+test_name 'CLOUD-282 - C64687 - Create vSphere VM from template'
+
+datacenter   = "opdx1"
+path         = '/opdx1/vm/eng/integration/vm'
+name         = SecureRandom.hex(8)
+name_path    = "#{path}/#{name}"
+status       = 'present'
+source_path  = '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349'
+is_template  = 'false'
+
+environment_base_path = on(master, puppet('config', 'print', 'environmentpath')).stdout.rstrip
+prod_env_site_pp_path = File.join(environment_base_path, 'production', 'manifests', 'site.pp')
+
+#ERB Template
+local_files_root_path = ENV['FILES'] || 'files'
+manifest_template     = File.join(local_files_root_path, 'manifest.erb')
+manifest_erb          = ERB.new(File.read(manifest_template)).result(binding)
+
+teardown do
+  agents.each do |agent|
+    ensure_absent(agent, path, name)
+  end
+end
+
+step "Manipulate the site.pp file  on the master node"
+site_pp = create_site_pp(master, :manifest => manifest_erb)
+inject_site_pp(master, prod_env_site_pp_path, site_pp)
+
+confine :except, :roles => %w{master dashboard database}
+step "Creating VM from a template on agent node:"
+agents.each do |agent|
+  on(agent, puppet('agent', '-t', '--environment production'), :acceptable_exit_codes => [0,2]) do |result|
+    assert_match(/#{name}\]\/ensure: changed absent to present/, result.output, 'Failed to create VM from template')
+  end
+end
+step "Verify the VM has been successfully created in vCenter:"
+is_created?(datacenter, "#{name}", "VM")


### PR DESCRIPTION
The pre-suite will install PE master and PE agent, and then install vSphere module from staging forge.

Before running the test, make sure all the ENV variables are correctly setup as below:
export VSPHERE_SERVER=vmware-vc1.ops.puppetlabs.net
export VSPHERE_USER=YOUR PUPPET LABS LDAP ACCOUNT USERNAME
export VSPHERE_PASSWORD=YOUR PUPPET LABS LDAP ACCOUNT PASSWORD

To run the test, execute any script in folder integration/test_run_scripts/vsphere
