### PR TITLE
(MAINT) fixes incorrect ensure state output after create.

### DIFF
--- a/lib/puppet/type/vsphere_machine.rb
+++ b/lib/puppet/type/vsphere_machine.rb
@@ -87,7 +87,7 @@ Puppet::Type.newtype(:vsphere_machine) do
     end
     def change_to_s(current, desired)
       current = :running if current == :present
-      desired = current if desired == :present
+      desired = current if desired == :present and current != :absent
       current == desired ? current : "changed #{current} to #{desired}"
     end
     def insync?(is)


### PR DESCRIPTION
Previously, this line was causing the erroneous output of `ensure: absent` at the end of a create. The original change was to prevent the the erroneous output of `ensure: running` regardless of the powerState of the vm. I feel that this is the only way to get the correct powerState to print while the resource is present and still print out the correct ensure value on create and destroy.
