### PR TITLE
(CLOUD-339) Add initial integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: ruby
-bundler_args: --without development acceptance
+bundler_args: --without development acceptance integration
 cache: bundler
 before_install: rm Gemfile.lock || true
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gem 'rbvmomi'
 gem 'hocon'
@@ -21,4 +21,14 @@ end
 
 group :acceptance do
   gem 'mustache'
+end
+
+# master_manipulator is only available from an internal
+# gem mirror so rather than break the default bundle
+# install we guard that
+unless ENV['GEM_SOURCE'].nil?
+  group :integration do
+    gem 'beaker', '~> 2.7'
+    gem 'master_manipulator', '~> 1.0'
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'metadata-json-lint/rake_task'
 
-# These two gems aren't always present, for instance
+# This gem isn't always present, for instance
 # on Travis with --without development
 begin
   require 'puppet_blacksmith/rake_tasks'
@@ -39,3 +39,24 @@ task :test => [
   :lint,
   :spec,
 ]
+
+namespace :integration do
+  [
+    'centos6',
+    'centos7',
+    'rhel7m_ubuntua',
+    'ubuntum_rhel7a',
+  ].each do |config|
+    desc "Run integration tests for #{config}"
+    task config.to_sym do
+      begin
+        require 'master_manipulator'
+        sh("integration/test_run_scripts/vsphere/vsphere_#{config}.sh")
+      rescue LoadError
+        puts "\033[33m[Warning]\033[0m The integration tests require the" \
+          ' master_manipulatotor gem which is only available from the internal' \
+          ' gem mirror. Specify GEM_SOURCE and rerun bundle install'
+      end
+    end
+  end
+end

--- a/integration/files/manifest.erb
+++ b/integration/files/manifest.erb
@@ -1,0 +1,8 @@
+vsphere_vm { '<%= name_path %>':
+  ensure          => <%= status %>,
+  source          => '<%= source_path %>',
+  resource_pool   => 'general1',
+  memory          => 512,
+  cpus            => 1,
+  template        => '<%= is_template %>',
+}

--- a/integration/files/vcenter_conf.erb
+++ b/integration/files/vcenter_conf.erb
@@ -1,0 +1,5 @@
+vcenter: {
+  host: <%= server %>
+  user: <%= user %>
+  password: <%= password %>
+}

--- a/integration/lib/vsphere_helper.rb
+++ b/integration/lib/vsphere_helper.rb
@@ -1,0 +1,24 @@
+require 'rbvmomi'
+
+def ensure_vm_is_absent(host, name)
+  on(host, "puppet apply -e \"vsphere_vm { '#{name}': ensure => 'absent'}\"")
+end
+
+def machine_exists?(datacenter, name, path)
+  server  = ENV['VCENTER_SERVER']
+  userid  = ENV['VCENTER_USER']
+  passwd  = ENV['VCENTER_PASSWORD']
+
+  vim = RbVmomi::VIM.connect insecure: 'true', host: server, user: userid, password: passwd
+  dc = vim.serviceInstance.find_datacenter(datacenter) or fail "datacenter not found"
+  vm = dc.find_vm("#{path}/#{name}")
+  fail_test "Cannot find the #{type}: #{name}" unless vm
+end
+
+def vm_exists?(datacenter, name)
+  machine_exists(datacenter, name, '/eng/integration/vm')
+end
+
+def template_exists?(datacenter, name)
+  machine_exists(datacenter, name, '/eng/integration/template')
+end

--- a/integration/pre-suite/0_install_pe/00_pe_install.rb
+++ b/integration/pre-suite/0_install_pe/00_pe_install.rb
@@ -1,0 +1,14 @@
+require 'master_manipulator'
+test_name 'Install Puppet Enterprise'
+
+step 'Install PE'
+install_pe
+
+step 'Disable Node Classifier'
+disable_node_classifier(master)
+
+step 'Disable environment caching'
+disable_env_cache(master)
+
+step 'Restart Puppet Server'
+restart_puppet_server(master)

--- a/integration/pre-suite/1_install_vsphere_module/00_install_vsphere_from_staging_forge.rb
+++ b/integration/pre-suite/1_install_vsphere_module/00_install_vsphere_from_staging_forge.rb
@@ -1,0 +1,12 @@
+test_name "QA-1912 - C64678 - Install using 'puppet module install puppetlabs-vsphere' command"
+
+step 'Setting Staging Forge'
+stub_forge_on(master)
+
+step 'Install puppetlabs-vsphere module on master'
+on(master, puppet('module install puppetlabs-vsphere'))
+
+agents.each do |agent|
+  step 'install rbvmomi and hocon gems'
+  on(agent, '/opt/puppet/bin/gem install rbvmomi hocon')
+end

--- a/integration/pre-suite/1_install_vsphere_module/01_set_credentials.rb
+++ b/integration/pre-suite/1_install_vsphere_module/01_set_credentials.rb
@@ -1,0 +1,17 @@
+# This file is only for local testing
+# CI task will have its own credentials
+require 'erb'
+
+confine :except, :roles => %w{master dashboard database}
+
+step 'Exporting credentials'
+server    = ENV['VCENTER_SERVER']
+user      = ENV['VCENTER_USER']
+password  = ENV['VCENTER_PASSWORD']
+
+step 'Add env var to hosts'
+agents.each do |agent|
+  agent.add_env_var("VCENTER_SERVER", "#{server}")
+  agent.add_env_var("VCENTER_USER", "#{user}")
+  agent.add_env_var("VCENTER_PASSWORD", "#{password}")
+end

--- a/integration/test_run_scripts/configs/centos-6-x86_64.cfg
+++ b/integration/test_run_scripts/configs/centos-6-x86_64.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  centos-6-x86_64-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-6-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-6-x86_64
+    hypervisor: vcloud
+  centos-6-x86_64-agent:
+    roles:
+      - agent
+    platform: el-6-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-6-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/integration/test_run_scripts/configs/centos-7-x86_64.cfg
+++ b/integration/test_run_scripts/configs/centos-7-x86_64.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  centos-7-x86_64-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+  centos-7-x86_64-agent:
+    roles:
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/integration/test_run_scripts/configs/rhel7m-ubuntua-x86_64.cfg
+++ b/integration/test_run_scripts/configs/rhel7m-ubuntua-x86_64.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+    hypervisor: vcloud
+  agent:
+    roles:
+      - agent
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/integration/test_run_scripts/configs/ubuntum-rhel7a-x86_64.cfg
+++ b/integration/test_run_scripts/configs/ubuntum-rhel7a-x86_64.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: ubuntu-14.04-amd64
+    template: Delivery/Quality Assurance/Templates/vCloud/ubuntu-1404-x86_64
+    hypervisor: vcloud
+  agent:
+    roles:
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/integration/test_run_scripts/vsphere/vsphere_centos6.sh
+++ b/integration/test_run_scripts/vsphere/vsphere_centos6.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+SCRIPT_PATH=$(pwd)
+BASENAME_CMD="basename ${SCRIPT_PATH}"
+SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
+
+if [ $SCRIPT_BASE_PATH = "vsphere" ]; then
+  cd ../../
+fi
+export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.8.0/
+export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
+
+bundle install --without acceptance development test --path .bundle/gems
+
+bundle exec beaker \
+  --config test_run_scripts/configs/centos-6-x86_64.cfg \
+  --debug \
+  --pre-suite pre-suite \
+  --test tests \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --load-path lib \
+  --preserve-host \
+  --timeout 360
+
+rm -rf .bundle

--- a/integration/test_run_scripts/vsphere/vsphere_centos7.sh
+++ b/integration/test_run_scripts/vsphere/vsphere_centos7.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+SCRIPT_PATH=$(pwd)
+BASENAME_CMD="basename ${SCRIPT_PATH}"
+SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
+
+if [ $SCRIPT_BASE_PATH = "vsphere" ]; then
+  cd ../../
+fi
+export pe_dist_dir=http://pe-releases.puppetlabs.lan/3.8.0/
+export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
+
+bundle install --without acceptance development test --path .bundle/gems
+
+bundle exec beaker \
+  --config test_run_scripts/configs/centos-7-x86_64.cfg \
+  --debug \
+  --pre-suite pre-suite \
+  --test tests \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --load-path lib \
+  --preserve-host \
+  --timeout 360
+
+rm -rf .bundle

--- a/integration/test_run_scripts/vsphere/vsphere_rhel7m_ubuntua.sh
+++ b/integration/test_run_scripts/vsphere/vsphere_rhel7m_ubuntua.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+SCRIPT_PATH=$(pwd)
+BASENAME_CMD="basename ${SCRIPT_PATH}"
+SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
+
+if [ $SCRIPT_BASE_PATH = "vsphere" ]; then
+  cd ../../
+fi
+
+export pe_dist_dir: http://pe-releases.puppetlabs.lan/3.8.0/
+export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
+
+bundle install --without acceptance development test --path .bundle/gems
+
+bundle exec beaker \
+  --config test_run_scripts/configs/rhel7m-ubuntua-x86_64.cfg \
+  --debug \
+  --pre-suite pre-suite \
+  --test tests \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --load-path lib \
+  --preserve-host \
+  --timeout 360
+
+rm -rf .bundle

--- a/integration/test_run_scripts/vsphere/vsphere_ubuntum_rhel7a.sh
+++ b/integration/test_run_scripts/vsphere/vsphere_ubuntum_rhel7a.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+SCRIPT_PATH=$(pwd)
+BASENAME_CMD="basename ${SCRIPT_PATH}"
+SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
+
+if [ $SCRIPT_BASE_PATH = "vsphere" ]; then
+  cd ../../
+fi
+
+export pe_dist_dir: http://pe-releases.puppetlabs.lan/3.8.0/
+export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
+
+bundle install --without acceptance development test --path .bundle/gems
+
+bundle exec beaker \
+  --config test_run_scripts/configs/ubuntum-rhel7a-x86_64.cfg \
+  --debug \
+  --pre-suite pre-suite \
+  --test tests \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --load-path lib \
+  --preserve-host \
+  --timeout 360
+
+rm -rf .bundle

--- a/integration/tests/01_create_vm_from_template.rb
+++ b/integration/tests/01_create_vm_from_template.rb
@@ -1,0 +1,44 @@
+require 'vsphere_helper'
+require 'SecureRandom'
+require 'erb'
+require 'rbvmomi'
+require 'master_manipulator'
+
+test_name 'CLOUD-282 - C64687 - Create vSphere VM from template'
+
+datacenter   = "opdx1"
+folder       = '/opdx1/vm/eng/integration/vm'
+name         = SecureRandom.hex(8)
+path         = "#{folder}/#{name}"
+status       = 'present'
+source_path  = '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349'
+is_template  = 'false'
+
+environment_base_path = on(master, puppet('config', 'print', 'environmentpath')).stdout.rstrip
+prod_env_site_pp_path = File.join(environment_base_path, 'production', 'manifests', 'site.pp')
+
+#ERB Template
+local_files_root_path = ENV['FILES'] || 'files'
+manifest_template     = File.join(local_files_root_path, 'manifest.erb')
+manifest_erb          = ERB.new(File.read(manifest_template)).result(binding)
+
+teardown do
+  agents.each do |agent|
+    ensure_vm_is_absent(agent, path)
+  end
+end
+
+step "Manipulate the site.pp file on the master node"
+site_pp = create_site_pp(master, :manifest => manifest_erb)
+inject_site_pp(master, prod_env_site_pp_path, site_pp)
+
+confine :except, :roles => %w{master dashboard database}
+step "Creating VM from a template on agent node:"
+agents.each do |agent|
+  on(agent, puppet('agent', '-t', '--environment production'), :acceptable_exit_codes => [0,2]) do |result|
+    assert_match(/#{name}\]\/ensure: changed absent to present/, result.output, 'Failed to create VM from template')
+  end
+end
+
+step "Verify the VM has been successfully created in vCenter:"
+vm_exists?(datacenter, "#{name}")


### PR DESCRIPTION
Reworking https://github.com/puppetlabs/puppetlabs-vsphere/pull/26/files based on comments on that PR. This:
- Rebases against the current master
- Adds a Rake task to run the integration tests (using the existing shell scripts), which fails gracefully when master_manipulator isn't installed
- Fixed the Travis configuration to not try and install master_manipulator (Travis builds now pass)
- Modified the Gemfile to only try and install master_manipulator if the internal GEM_SOURCE is set
- Tidied up some of the helper methods to provide a clearer interface as commented on original PR
- Removed some commented out code
