### PR TITLE
Remove memory and cpu on template erb after the fix for CLOUD-361

### DIFF
--- a/integration/files/manifest.erb
+++ b/integration/files/manifest.erb
@@ -1,7 +1,7 @@
 vsphere_vm { '<%= path %>':
   ensure          => <%= status %>,
   source          => '<%= source_path %>',
-  memory          => 512,
-  cpus            => 1,
+  memory          => '<%= memory %>',
+  cpus            =>  '<%= cpus %>',
   template        => '<%= is_template %>',
 }

--- a/integration/tests/01_create_vm_from_template.rb
+++ b/integration/tests/01_create_vm_from_template.rb
@@ -12,7 +12,10 @@ name         = SecureRandom.hex(8)
 path         = "#{folder}/#{name}"
 status       = 'present'
 source_path  = '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349'
+memory       = '512'
+cpus         = '1'
 is_template  = 'false'
+annotation   = 'Create VM from template'
 
 environment_base_path = on(master, puppet('config', 'print', 'environmentpath')).stdout.rstrip
 prod_env_site_pp_path = File.join(environment_base_path, 'production', 'manifests', 'site.pp')

--- a/integration/tests/02_create_vm_from_template_to_stopped_state.rb
+++ b/integration/tests/02_create_vm_from_template_to_stopped_state.rb
@@ -12,7 +12,10 @@ name         = SecureRandom.hex(8)
 path         = "#{folder}/#{name}"
 status       = 'stopped'
 source_path  = '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349'
+memory       = '512'
+cpus         = '1'
 is_template  = 'false'
+annotation   = 'Create VM from template and to powered off state'
 
 environment_base_path = on(master, puppet('config', 'print', 'environmentpath')).stdout.rstrip
 prod_env_site_pp_path = File.join(environment_base_path, 'production', 'manifests', 'site.pp')

--- a/integration/tests/03_create_vm_from_vm_to_running_state.rb
+++ b/integration/tests/03_create_vm_from_vm_to_running_state.rb
@@ -12,7 +12,10 @@ name         = SecureRandom.hex(8)
 path         = "#{folder}/#{name}"
 status       = 'stopped'
 source_path  = '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349'
+memory       = '512'
+cpus         = '1'
 is_template  = 'false'
+annotation   = 'Create VM from template'
 
 environment_base_path = on(master, puppet('config', 'print', 'environmentpath')).stdout.rstrip
 prod_env_site_pp_path = File.join(environment_base_path, 'production', 'manifests', 'site.pp')
@@ -51,7 +54,11 @@ step "Manipulate the site.pp file on the master node the second time"
 path              = "#{folder}/vm_from_vm_#{name}"
 status            = 'running'
 source_path       = "#{folder}/#{name}"
+memory            = '512'
+cpus              = '1'
 is_template       = 'false'
+annotation        = 'Create VM from VM and to running state'
+
 manifest_template = File.join(local_files_root_path, 'manifest.erb')
 manifest_erb      = ERB.new(File.read(manifest_template)).result(binding)
 

--- a/integration/tests/04_create_template_from_vm.rb
+++ b/integration/tests/04_create_template_from_vm.rb
@@ -12,7 +12,10 @@ name         = SecureRandom.hex(8)
 path         = "#{folder}/vm/#{name}"
 status       = 'stopped'
 source_path  = '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349'
+memory       = '512'
+cpus         = '1'
 is_template  = 'false'
+annotation   = 'Create VM from template'
 
 environment_base_path = on(master, puppet('config', 'print', 'environmentpath')).stdout.rstrip
 prod_env_site_pp_path = File.join(environment_base_path, 'production', 'manifests', 'site.pp')
@@ -50,8 +53,13 @@ path              = "#{folder}/template/template_from_vm_#{name}"
 status            = 'present'
 source_path       = "#{folder}/vm/#{name}"
 is_template       = 'true'
+annotation   = 'Create template from VM'
 manifest_template = File.join(local_files_root_path, 'manifest.erb')
 manifest_erb      = ERB.new(File.read(manifest_template)).result(binding)
+
+# Delete Memory and CPUs from the manifest ERB file:
+manifest_erb = manifest_erb.sub(/memory.*/, "")
+manifest_erb = manifest_erb.sub(/cpus.*/, "")
 
 site_pp = create_site_pp(master, :manifest => manifest_erb)
 inject_site_pp(master, prod_env_site_pp_path, site_pp)

--- a/integration/tests/05_create_vm-template_wit_existing_name.rb
+++ b/integration/tests/05_create_vm-template_wit_existing_name.rb
@@ -12,7 +12,10 @@ name         = SecureRandom.hex(8)
 path         = "#{folder}/vm/#{name}"
 status       = 'running'
 source_path  = '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349'
+memory       = '512'
+cpus         = '1'
 is_template  = 'false'
+annotation   = 'Create VM from template'
 
 environment_base_path = on(master, puppet('config', 'print', 'environmentpath')).stdout.rstrip
 prod_env_site_pp_path = File.join(environment_base_path, 'production', 'manifests', 'site.pp')
@@ -59,8 +62,13 @@ path              = "#{folder}/template/template_from_vm_#{name}"
 status            = 'present'
 source_path       = "#{folder}/vm/#{name}"
 is_template       = 'true'
+annotation   = 'Create template from VM'
 manifest_template = File.join(local_files_root_path, 'manifest.erb')
 manifest_erb      = ERB.new(File.read(manifest_template)).result(binding)
+
+# Delete Memory and CPUs from the manifest ERB file:
+manifest_erb = manifest_erb.sub(/memory.*/, "")
+manifest_erb = manifest_erb.sub(/cpus.*/, "")
 
 site_pp = create_site_pp(master, :manifest => manifest_erb)
 inject_site_pp(master, prod_env_site_pp_path, site_pp)


### PR DESCRIPTION
After the fix for CLOUD-361, creating a template with memory and cpu will fail the test since these params are no longer needed for creating a template. 

This PR fixes the problem by deleting the memory and cpus line in manifest.erb file before creating a template
