### PR TITLE
(CLOUD-370) Retry partial API read failures

### DIFF
--- a/lib/puppet/provider/vsphere_vm/rbvmomi.rb
+++ b/lib/puppet/provider/vsphere_vm/rbvmomi.rb
@@ -49,7 +49,7 @@ Puppet::Type.type(:vsphere_vm).provide(:rbvmomi, :parent => PuppetX::Puppetlabs:
     with_retries(:max_tries => 10,
                  :handler => handler,
                  :max_sleep_seconds => 2,
-                 :rescue => RbVmomi::Fault) do
+                 :rescue => [RbVmomi::Fault, NoMethodError]) do
       name = machine.path.collect { |x| x[1] }.drop(1).join('/')
       resource_pool = machine.resourcePool
       resource_pool = resource_pool ? resource_pool.parent.name : nil
@@ -58,6 +58,8 @@ Puppet::Type.type(:vsphere_vm).provide(:rbvmomi, :parent => PuppetX::Puppetlabs:
       config = machine.config
       hostname = summary.guest.hostName
       extra_config = {}
+      # we catch NoMethodError and retry as it's possible during
+      # creation and deletion for config to return nil
       config.extraConfig.map do |setting|
         extra_config[setting.key] = setting.value
       end


### PR DESCRIPTION
We already retry client failures but it's also possible for the API
client to return nil instead of raise an expcetion. This appears to
happen mainly around creation and deletion events when presumably the
API is in a transient state. This change retries for those cases as
well.
