### PR TITLE
(CLOUD-370) Change formulation for API queries

### DIFF
--- a/lib/puppet/provider/vsphere_vm/rbvmomi.rb
+++ b/lib/puppet/provider/vsphere_vm/rbvmomi.rb
@@ -28,6 +28,19 @@ Puppet::Type.type(:vsphere_vm).provide(:rbvmomi, :parent => PuppetX::Puppetlabs:
     end
   end
 
+  def self.query_vm_properties(machine, mappings)
+    list_of_values = machine.collect(*mappings.values)
+    hash_of_values = {}
+    list_of_values.each_with_index do |value, i|
+      hash_of_values[mappings.values[i]] = value
+    end
+    response = {}
+    mappings.each do |key, value|
+      response[key] = hash_of_values[value]
+    end
+    response
+  end
+
   def self.machine_to_hash(machine)
     handler = Proc.new do |exception, attempt_number, total_delay|
       Puppet.debug("#{exception.class}: #{exception.message}; retry attempt #{attempt_number}; #{total_delay} seconds have passed")
@@ -64,38 +77,44 @@ Puppet::Type.type(:vsphere_vm).provide(:rbvmomi, :parent => PuppetX::Puppetlabs:
       resource_pool = machine.resourcePool
       resource_pool = resource_pool ? resource_pool.parent.name : nil
       state = machine_state(machine)
-      summary = machine.summary
-      config = machine.config
-      hostname = summary.guest.hostName
       extra_config = {}
-      # we catch NoMethodError and retry as it's possible during
-      # creation and deletion for config to return nil
-      config.extraConfig.map do |setting|
+
+      property_mappings = {
+        cpus: 'summary.config.numCpu',
+        config: 'config.extraConfig',
+        snapshot_disabled: 'config.flags.snapshotDisabled',
+        snapshot_locked: 'config.flags.snapshotLocked',
+        annotation: 'config.annotation',
+        snapshot_power_off_behavior: 'config.flags.snapshotPowerOffBehavior',
+        memory: 'summary.config.memorySizeMB',
+        template: 'summary.config.template',
+        memory_reservation: 'summary.config.memoryReservation',
+        cpu_reservation: 'summary.config.cpuReservation',
+        number_ethernet_cards: 'summary.config.numEthernetCards',
+        power_state: 'summary.runtime.powerState',
+        tools_installer_mounted: 'summary.runtime.toolsInstallerMounted',
+        uuid: 'summary.config.uuid',
+        instance_uuid: 'summary.config.instanceUuid',
+        hostname: 'summary.guest.hostName',
+      }
+
+      api_properties = query_vm_properties(machine, property_mappings)
+
+      api_properties[:config].each do |setting|
         extra_config[setting.key] = setting.value
       end
+      api_properties.delete(:config)
 
-      {
+      curated_properties = {
         name: "/#{name}",
-        memory: summary.config.memorySizeMB,
-        cpus: summary.config.numCpu,
         resource_pool: resource_pool,
-        template: summary.config.template,
         ensure: state,
-        memory_reservation: summary.config.memoryReservation,
-        cpu_reservation: summary.config.cpuReservation,
-        number_ethernet_cards: summary.config.numEthernetCards,
-        power_state: summary.runtime.powerState,
-        tools_installer_mounted: summary.runtime.toolsInstallerMounted,
-        snapshot_disabled: config.flags.snapshotDisabled,
-        snapshot_locked: config.flags.snapshotLocked,
-        snapshot_power_off_behavior: config.flags.snapshotPowerOffBehavior,
-        uuid: summary.config.uuid,
-        instance_uuid: summary.config.instanceUuid,
         guest_ip: machine.guest_ip,
-        hostname: hostname == '(none)' ? nil : hostname,
+        hostname: api_properties['hostname'] == '(none)' ? nil : api_properties['hostname'],
         extra_config: extra_config,
-        annotation: config.annotation,
       }
+
+      api_properties.merge(curated_properties)
     end
   end
 


### PR DESCRIPTION
This commit changes how we call the API, and is based on research into
the extraConfig failures. I found this commit on a vmware project that
uses rbvmomi:

https://github.com/vmware/rvc/commit/ec900bf0df1871ac1d0b429e79d38f7629181925

This led me to this the comment in the rbvmomi source code this states that collect should
"Efficiently retrieve multiple properties from an object"

https://github.com/rlane/rbvmomi/blob/5dc0ca33165519a83f4eb8765835ac8f17306f84/lib/rbvmomi/vim/ManagedObject.rb#L27-L30

In the worst case this further reduces the number of separate API calls,
we no longer call summary and config separately.

Given I've been unable to trigger the failure we've seen in CI locally
this may also resolve that too, with this change we no-longer ask for config
but instead ask for config.extraConfig directly.
