### PR TITLE
(MAINT) disallow names that are too long for vSphere

### DIFF
--- a/lib/puppet/type/vsphere_vm.rb
+++ b/lib/puppet/type/vsphere_vm.rb
@@ -95,6 +95,7 @@ Puppet::Type.newtype(:vsphere_vm) do
     validate do |value|
       fail 'Virtual machine name should be a String' unless value.is_a? String
       fail 'Virtual machines must have a name' if value == ''
+      fail 'The last part of the path should be no more than 40 characters long' if value.split('/')[-1].size > 40
     end
   end
 

--- a/spec/unit/type/vsphere_vm_spec.rb
+++ b/spec/unit/type/vsphere_vm_spec.rb
@@ -63,6 +63,12 @@ describe type_class do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should require the last part of the name to be no more than 40 characters' do
+    expect {
+      type_class.new({name: '/dc/vm/a-far-too-long-name-with-lots-of-words-in-it'})
+    }.to raise_error(Puppet::Error, /should be no more than 40 characters/)
+  end
+
   [
     'name',
     'resource_pool',


### PR DESCRIPTION
According to user reports and page 31 of https://pubs.vmware.com/vsphere-50/topic/com.vmware.ICbase/PDF/vsphere-esxi-vcenter-server-501-virtual-machine-admin-guide.pdf
vSphere only allows the name portion of the path to be 40 characters in
length.
