### PR TITLE
(CLOUD-386) avoid issues with reserved characters in HOCON

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ file. Store this as `vcenter.conf` in the relevant
 
       ~~~
       vcenter: {
-        host: 'your-host'
-        user: 'your-username'
-        password: 'your-password'
+        host: "your-host"
+        user: "your-username"
+        password: "your-password"
       }
       ~~~
 
@@ -110,9 +110,9 @@ file. Store this as `vcenter.conf` in the relevant
 
       ~~~
       vcenter: {
-        host: 'your-host'
-        user: 'your-username'
-        password: 'your-password'
+        host: "your-host"
+        user: "your-username"
+        password: "your-password"
         port: your-port
         insecure: false
         ssl: false


### PR DESCRIPTION
Using single quotes means you can't use reserved characters like @.
Although we produce a suitable error message if this occurs we can
probably avoid a few issues simply by changing the reference config file
to use double quotes.
