### PR TITLE
(CLOUD-345) Performance improvements for prefetch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'hocon'
 
 group :test do
   gem 'rake'
-  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '~> 3.7.0'
+  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
   gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'

--- a/lib/puppet_x/puppetlabs/vsphere.rb
+++ b/lib/puppet_x/puppetlabs/vsphere.rb
@@ -42,11 +42,51 @@ module PuppetX
       end
 
       def self.find_vms_in_folder(folder)
-        vim.serviceContent.viewManager.CreateContainerView({
-          container: folder,
-          type: ['VirtualMachine'],
-          recursive: true,
-        }).view
+        filter_spec = RbVmomi::VIM.PropertyFilterSpec(
+          :objectSet => [
+            :obj => folder,
+            :skip => true,
+            :selectSet => [
+              RbVmomi::VIM.TraversalSpec(
+                :name => 'VisitFolders',
+                :type => 'Folder',
+                :path => 'childEntity',
+                :skip => false,
+                :selectSet => [
+                  RbVmomi::VIM.SelectionSpec(:name => 'VisitFolders')
+                ]
+              )
+            ]
+          ],
+          :propSet => [{
+            :type => 'VirtualMachine',
+            :pathSet => [
+              'name',
+              'resourcePool',
+              'guest.ipAddress',
+              'summary.config.instanceUuid',
+              'summary.config.numCpu',
+              'config.extraConfig',
+              'config.flags.snapshotDisabled',
+              'config.flags.snapshotLocked',
+              'config.annotation',
+              'config.guestFullName',
+              'config.flags.snapshotPowerOffBehavior',
+              'summary.config.memorySizeMB',
+              'summary.config.template',
+              'summary.config.memoryReservation',
+              'summary.config.cpuReservation',
+              'summary.config.numEthernetCards',
+              'summary.runtime.powerState',
+              'summary.runtime.toolsInstallerMounted',
+              'summary.config.uuid',
+              'summary.config.instanceUuid',
+              'summary.guest.hostName',
+              'runtime.powerState',
+            ]
+          }]
+        )
+        vim.propertyCollector.RetrieveProperties(:specSet => [filter_spec])
       end
 
       private

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -15,7 +15,7 @@ class PuppetManifest < Mustache
 
   def apply
     manifest = self.render.gsub("\n", '')
-    cmd = "bundle exec puppet apply --detailed-exitcodes -e \"#{manifest}\" --modulepath ../ --libdir lib"
+    cmd = "bundle exec puppet apply --detailed-exitcodes -e \"#{manifest}\" --modulepath ../ --libdir lib --debug"
     result = { output: [], exit_status: nil }
 
     Open3.popen2e(cmd) do |stdin, stdout_err, wait_thr|

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,7 +1,7 @@
 vsphere_vm { '/opdx1/vm/eng/garethr/garethr-test':
   ensure => present,
   source => '/opdx1/vm/eng/templates/debian-wheezy-3.2.0.4-amd64-vagrant-vmtools_9349',
-  memory => 1024,
+  memory => 512,
   cpus   => 2,
 }
 


### PR DESCRIPTION
Prefecth previously triggered lots of queries for every VM. This could
add around a second per vm in some cases, leading to long run times.

This changes collects lots of the properties up-front, drastically
reducing the query time.
