### PR TITLE
Add .env to development gems.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ integration/tmp
 log
 junit
 tmp
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :development do
   gem 'guard-rake'
   gem 'pry-rescue'
   gem 'pry-stack_explorer'
+  gem 'dotenv'
 end
 
 group :acceptance do


### PR DESCRIPTION
I've added `dotenv` to the development gems list and added `.env` files to
the `.gitignore` file.

Given how much testing this module revolves around having proper env
vars or a config file set up, this Gem made things significantly easier
for me while I was working on it.

I don't think this should require any tests, etc., as it's got nothing
to do with the functioning of the module, but please correct me if I'm
wrong.
