### PR TITLE
(FM-4623) Fails to load some instances

### DIFF
--- a/lib/puppet/provider/vsphere_vm/rbvmomi.rb
+++ b/lib/puppet/provider/vsphere_vm/rbvmomi.rb
@@ -54,12 +54,16 @@ Puppet::Type.type(:vsphere_vm).provide(:rbvmomi, :parent => PuppetX::Puppetlabs:
   def self.resource_pool_from_machine_data(machine, data)
     path_components = []
     i = data[RbVmomi::VIM::ResourcePool][machine['resourcePool']]
+
     while i
       path_components << i['name']
       if i.has_key? 'parent'
-        if data[RbVmomi::VIM::ResourcePool].has_key? i['parent']
+        if data[RbVmomi::VIM::ResourcePool].has_key?(i['parent'])
           i = data[RbVmomi::VIM::ResourcePool][i['parent']]
-        elsif data[RbVmomi::VIM::ClusterComputeResource].has_key? i['parent']
+        elsif data[RbVmomi::VIM::ComputeResource] && data[RbVmomi::VIM::ComputeResource].has_key?(i['parent'])
+          path_components.pop
+          i = data[RbVmomi::VIM::ComputeResource][i['parent']]
+        elsif data[RbVmomi::VIM::ClusterComputeResource] && data[RbVmomi::VIM::ClusterComputeResource].has_key?(i['parent'])
           # There's always a top-level "Resources" pool that we do not want to show
           path_components.pop
           i = data[RbVmomi::VIM::ClusterComputeResource][i['parent']]

--- a/lib/puppet_x/puppetlabs/vsphere.rb
+++ b/lib/puppet_x/puppetlabs/vsphere.rb
@@ -207,6 +207,14 @@ module PuppetX
               ]
             },
             {
+              :type => 'ComputeResource',
+              :pathSet => [
+                'name',
+                'parent',
+                'configurationEx',
+              ]
+            },
+            {
               :type => 'ClusterComputeResource',
               :pathSet => [
                 'name',


### PR DESCRIPTION
The module fails to load instances where the resource pool is
associated with the host or a compute resource that is not
a base ResourcePool or a ClusterComputeResource. An update has been made
to add the base ComputeResource to the filter spec as well as
querying for the ComputeResource in the `resource_pool_from_machine_data`
method.

An additional nil check was added because in some scenarios the
machine data will not contain ClusterComputeResource or
ComputeResource.

/cc @DavidS for review
