### PR TITLE
Add note for DOMAIN\user account triple quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ file. Store this as `vcenter.conf` in the relevant
         ssl: false
       }
       ```
+    **Warning**: Usernames that contain a backslash, typically Active Directory domain accounts, must be triple-quoted. For example:
+    
+      ```
+      vcenter: {
+        host: "your-host"
+        user: """DOMAIN\your-username"""
+        password: "your-password"
+      }
+      ```
 
     Note that you can use either the environment variables or the config file. If both are present the environment variables will be used. You **cannot** have some settings in environment variables and others in the config file.
 


### PR DESCRIPTION
As per Gareth's comment on [MODULES-2753](https://tickets.puppetlabs.com/browse/MODULES-2753?focusedCommentId=231934&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-231934), AD domain accounts that contain a backslash must be triple quoted. This is extremely common, so let's note this for our users, to reduce confusion/unexpected behavior.
