### PR TITLE
Add Ubuntu Xenial to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04"
+        "14.04",
+        "16.04"
       ]
     }
   ],


### PR DESCRIPTION
adds Ubuntu 16.04 to supported ubuntu platforms on metadata.json