### PR TITLE
(FM-6227) Add support for a datastore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ vsphere_vm { '/opdx1/vm/eng/sample':
 }
 ```
 
+To create the same machine on a specific datastore add the `datastore` parameter:
+
+```
+vsphere_vm { '/opdx1/vm/eng/sample':
+  ensure    => stopped,
+  source    => '/opdx1/vm/eng/source',
+  datastore => 'datastore1',
+}
+```
+
+
 ## Usage
 
 ### List and manage vSphere machines
@@ -341,6 +352,12 @@ The source type of the new virtual machine. Valid options are 'vm' if the source
 is another virtual machine, 'template' if the source is a template, or 'folder'
 if the source is an imported/uploaded virtual machine folder on the datastore.
 Defaults to 'vm'.
+
+##### `datastore`
+The datastore name within the specified `resource_pool` where the virtual machine
+will be reside. This option is only available when creating a virtual machine from 
+a `source` and is required when specifying a different `resource_pool`.
+This defaults to the first datastore in the `resource_pool`.
 
 ##### `template`
 Whether or not the machine is a template. Defaults to false.

--- a/lib/puppet/type/vsphere_vm.rb
+++ b/lib/puppet/type/vsphere_vm.rb
@@ -118,6 +118,13 @@ Puppet::Type.newtype(:vsphere_vm) do
     newvalues(:true, :false)
   end
 
+  newparam(:datastore) do
+    desc 'The name of the datastore with which to associate the virtual machine. This is only appliciable when cloning a VM.'
+    validate do |value|
+      fail 'Virtual machine datastore should be a String' unless value.is_a? String
+    end
+  end
+
   newproperty(:memory) do
     desc 'The amount of memory in MB to use for the machine.'
     def insync?(is)
@@ -171,6 +178,7 @@ Puppet::Type.newtype(:vsphere_vm) do
       is.to_s == should.to_s
     end
   end
+
 
   read_only_properties = {
     cpu_reservation: 'cpuReservation',

--- a/spec/unit/type/vsphere_vm_spec.rb
+++ b/spec/unit/type/vsphere_vm_spec.rb
@@ -13,6 +13,7 @@ describe type_class do
       :linked_clone,
       :create_command,
       :delete_from_disk,
+      :datastore,
     ]
   end
 
@@ -203,6 +204,10 @@ describe type_class do
 
   it 'should require linked_clone to be a boolean' do
     expect{type_class.new(:name => 'sample', :linked_clone => 'sample')}.to raise_error
+  end
+
+  it 'should require datastore to be a string' do
+    expect{type_class.new(:name => 'sample', :datastore => true)}.to raise_error
   end
 
   [


### PR DESCRIPTION
This PR adds a new parameter `datastore` that will allow for
changing the destination datastore for the VM. The default `datastore`
is set to the first datastore available on the destination
`resource_pool`.

The `datastore` parameter is only utilized when cloning a VM from a source, but has a deviation from the existing behavior. Prior to this PR the VM would be cloned on the same datastore as the source VM/Template. This PR changes the default behavior to be the first datastore in the destination cluster. 