### PR TITLE
Adds task to install dependency gems for puppet server

### DIFF
--- a/tasks/install_deps.json
+++ b/tasks/install_deps.json
@@ -1,0 +1,5 @@
+{
+  "description": "Installs aws-sdk and retries gem for the puppetlabs/aws module",
+  "supports_noop": false,
+  "input_method": "environment"
+}

--- a/tasks/install_deps.sh
+++ b/tasks/install_deps.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+/opt/puppetlabs/bin/puppet resource package rbvmomi ensure=present provider=puppet_gem
+/opt/puppetlabs/bin/puppet resource package hocon ensure=present provider=puppet_gem


### PR DESCRIPTION
Most people would manage the gem install, but during their first run
they may just want to do it adhoc as part of experimenting.