### PR TITLE
(maint) - Updating testing to align with other modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - 'bundle exec rake $CHECK'
 bundler_args: --without system_tests
 rvm:
-  - 2.5.0
+  - 2.5.1
 env:
   global:
     - PUPPET_GEM_VERSION="~> 6.0"
@@ -27,9 +27,6 @@ matrix:
     -
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
       rvm: 2.4.4
-    -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
-      rvm: 2.1.9
 branches:
   only:
     - master


### PR DESCRIPTION
Currently this module is testing Puppet 6 on ruby 2.5.0 I am updating to stop testing on Puppet 4 and test on ruby 2.5.1 for Puppet 6 as this is the ruby version that ships with Puppet 6.

This aligns with all of our other supported modules.