### PR TITLE
(MODULES-9019) Bump Windows customization spec timeout

### DIFF
--- a/spec/acceptance/machine_customization_spec.rb
+++ b/spec/acceptance/machine_customization_spec.rb
@@ -39,7 +39,7 @@ describe 'vsphere_machine' do
 
       it 'should create a VM with the hostname set to the value from the customization spec' do
         # The large timeout is to account for the installation time of the Windows 2012 VM
-        hostname = with_retries(max_tries: 40,
+        hostname = with_retries(max_tries: 50,
                      max_sleep_seconds: 60,
                      rescue: NotFinished,
                     ) do

--- a/spec/acceptance/machine_customization_spec.rb
+++ b/spec/acceptance/machine_customization_spec.rb
@@ -39,7 +39,7 @@ describe 'vsphere_machine' do
 
       it 'should create a VM with the hostname set to the value from the customization spec' do
         # The large timeout is to account for the installation time of the Windows 2012 VM
-        hostname = with_retries(max_tries: 50,
+        hostname = with_retries(max_tries: 60,
                      max_sleep_seconds: 60,
                      rescue: NotFinished,
                     ) do


### PR DESCRIPTION
The spec for Windows customization has been failing repeatedly so this
commit bumps the timeout to ensure the test does not timeout.