### PR TITLE
(FM-8635) Comment out acceptance/machine_spec.rb:157

### DIFF
--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -155,7 +155,7 @@ describe 'vsphere_vm' do
 
 # Test cannot be ran as our vCenter licence does not support creating resource pools
 # FM-8635: Commenting out all test steps
-  # pending 'should be able to create a machine within a nested resource pool' do
+  pending 'should be able to create a machine within a nested resource pool' do
   #   before(:all) do
   #     @name = "MODULES-#{SecureRandom.hex(8)}"
   #     @path = "/opdx/vm/vsphere-module-testing/eng/tests/#{@name}"
@@ -187,7 +187,7 @@ describe 'vsphere_vm' do
   #     expect(@result.stdout).to match(regex)
   #   end
 
-  # end
+  end
 
   describe 'should be able to create a machine from another machine' do
     before(:all) do

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -154,39 +154,40 @@ describe 'vsphere_vm' do
   end
 
 # Test cannot be ran as our vCenter licence does not support creating resource pools
-  pending 'should be able to create a machine within a nested resource pool' do
-    before(:all) do
-      @name = "MODULES-#{SecureRandom.hex(8)}"
-      @path = "/opdx/vm/vsphere-module-testing/eng/tests/#{@name}"
-      @config = {
-        :name     => @path,
-        :ensure   => 'present',
-        :optional => {
-          :source        => '/opdx/vm/vsphere-module-testing/eng/templates/debian-8-x86_64',
-          :source_type   => :template,
-          :resource_pool => '/acceptance1/Resources',
-          :memory        => 512,
-          :cpus          => 1,
-        }
-      }
-      PuppetManifest.new(@template, @config).apply
-      @machine = @client.get_machine(@path)
-    end
+# FM-8635: Commenting out all test steps
+  # pending 'should be able to create a machine within a nested resource pool' do
+  #   before(:all) do
+  #     @name = "MODULES-#{SecureRandom.hex(8)}"
+  #     @path = "/opdx/vm/vsphere-module-testing/eng/tests/#{@name}"
+  #     @config = {
+  #       :name     => @path,
+  #       :ensure   => 'present',
+  #       :optional => {
+  #         :source        => '/opdx/vm/vsphere-module-testing/eng/templates/debian-8-x86_64',
+  #         :source_type   => :template,
+  #         :resource_pool => '/acceptance1/Resources',
+  #         :memory        => 512,
+  #         :cpus          => 1,
+  #       }
+  #     }
+  #     PuppetManifest.new(@template, @config).apply
+  #     @machine = @client.get_machine(@path)
+  #   end
 
-    after(:all) do
-      @client.destroy_machine(@path)
-    end
+  #   after(:all) do
+  #     @client.destroy_machine(@path)
+  #   end
 
-    it 'with the specified name' do
-      expect(@machine.name).to eq(@name)
-    end
+  #   it 'with the specified name' do
+  #     expect(@machine.name).to eq(@name)
+  #   end
 
-    it 'should report the correct resource_pool value' do
-      regex = /(resource_pool)(\s*)(=>)(\s*)('#{@config[:optional][:resource_pool]}')/
-      expect(@result.stdout).to match(regex)
-    end
+  #   it 'should report the correct resource_pool value' do
+  #     regex = /(resource_pool)(\s*)(=>)(\s*)('#{@config[:optional][:resource_pool]}')/
+  #     expect(@result.stdout).to match(regex)
+  #   end
 
-  end
+  # end
 
   describe 'should be able to create a machine from another machine' do
     before(:all) do


### PR DESCRIPTION
The vSphere CI acceptance tests have been failing with the following error:
```ruby
      `before` is not available from within an example (e.g. an `it` block) or from constructs that run in the scope of an example (e.g. `before`, `let`, etc). It is only available on an example group (e.g. a `describe` or `context` block).
     # ./spec/acceptance/machine_spec.rb:158:in `block (2 levels) in <top (required)>' 
```
https://jenkins-master-prod-1.delivery.puppetlabs.net/job/forge-module_puppetlabs-vsphere_intn-sys_smoke-master/PLATFORM=ubuntu1404-64default.mdca,WORKER_LABEL=beaker/39

`machine_spec.rb:157` was marked as 'pending' over a year ago as part of [FM-7082](https://tickets.puppetlabs.com/browse/FM-7082). Cannot determine why this is suddenly failing - RSpec documentation does not suggest that there's any issue with a Before block being nested under 'Pending', but, this appears to be why the pipeline is failing.

Given it is not running, we should just comment out this test until we can determine why this is the case or we enable this test (whatever comes first!).