### PR TITLE
(maint) Fix vSphere spec tests

### DIFF
--- a/spec/acceptance/machine_customization_spec.rb
+++ b/spec/acceptance/machine_customization_spec.rb
@@ -39,7 +39,7 @@ describe 'vsphere_machine' do
 
       it 'should create a VM with the hostname set to the value from the customization spec' do
         # The large timeout is to account for the installation time of the Windows 2012 VM
-        hostname = with_retries(max_tries: 40,
+        hostname = with_retries(max_tries: 60,
                      max_sleep_seconds: 60,
                      rescue: NotFinished,
                     ) do

--- a/spec/acceptance/machine_spec.rb
+++ b/spec/acceptance/machine_spec.rb
@@ -153,9 +153,11 @@ describe 'vsphere_vm' do
 
   end
 
-# Test cannot be ran as our vCenter licence does not support creating resource pools
+# Test cannot be run as our vCenter licence does not support creating resource pools
 # FM-8635: Commenting out all test steps
-  pending 'should be able to create a machine within a nested resource pool' do
+  it 'should be able to create a machine within a nested resource pool' do
+    pending('FM-8635: Test cannot be run as our vCenter licence does not support creating resource pools')
+    fail
   #   before(:all) do
   #     @name = "MODULES-#{SecureRandom.hex(8)}"
   #     @path = "/opdx/vm/vsphere-module-testing/eng/tests/#{@name}"


### PR DESCRIPTION
## Description
Two issues this PR is trying to solve:
- `machine_customization_spec.rb` is failing as it appears as though the amount of time we have given the Windows machines to reconfigure their hostname is not enough. Tested locally and 60 retries seems to be more reliable. Observed the VMs in vSphere in a lot of reboot cycles whilst the test was polling their status and timing out
- `machine_customization_spec.rb:158` Follows on from this PR: https://github.com/puppetlabs/puppetlabs-vsphere/pull/165 yesterday. It appears as though the status is still `Failing`, so, bizarrely, to get a pending status, I needed to nest a `fail` from within the pending block.

With these two changes, hoping the vSphere acceptance tests on Jenkins might go green 🤞 