### PR TITLE
(maint) Fix delete VM warning prompt

### DIFF
--- a/spec/tools/vsphere_vm_cleanup.rb
+++ b/spec/tools/vsphere_vm_cleanup.rb
@@ -34,7 +34,7 @@ end
 print "\nWould you like to delete these VMs? [Y/N]: "
 confirm = gets.chomp
 
-exit(0) unless confirm.casecmp('y')
+exit(0) unless confirm.casecmp('y') == 0
 
 3.downto(1) do |i|
   print "\rDeleting VMs in #{i}"


### PR DESCRIPTION
I should have done more testing and realised `casecmp` returns an int, not a boolean.