### PR TITLE
pdksync - Remove EL6 testing from Travis

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -14,9 +14,6 @@ docker_debian:
 docker_el:
   provisioner: docker
   images:
-  - litmusimage/centos:6
-  - litmusimage/oraclelinux:6
-  - litmusimage/scientificlinux:6
   - litmusimage/centos:7
   - litmusimage/oraclelinux:7
   - litmusimage/scientificlinux:7


### PR DESCRIPTION
Remove EL6 testing from Travis
pdk version: `1.18.1` 
