### PR TITLE
(MAINT) Replace deprecated '--no-rdoc' and '--no-ri' gem install opts

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -58,9 +58,9 @@ def install_module_deps
   # FM-8880: When the nokogiri gem is installed as part of the installation of rbvmomi or hocon (as it's a dep of both),
   # the installation fails on RHEL 7.x derived OSs. We need to install nokogiri first, standalone before installing the
   # subsequent gems.
-  Helper.instance.run_shell('/opt/puppetlabs/puppet/bin/gem install nokogiri --no-ri --no-rdoc')
-  Helper.instance.run_shell('/opt/puppetlabs/puppet/bin/gem install rbvmomi --no-ri --no-rdoc')
-  Helper.instance.run_shell("/opt/puppetlabs/puppet/bin/gem install hocon --version='~>1.0.0' --no-ri --no-rdoc")
+  Helper.instance.run_shell('/opt/puppetlabs/puppet/bin/gem install nokogiri --no-document')
+  Helper.instance.run_shell('/opt/puppetlabs/puppet/bin/gem install rbvmomi --no-document')
+  Helper.instance.run_shell("/opt/puppetlabs/puppet/bin/gem install hocon --version='~>1.0.0' --no-document")
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
The `--no-rdoc` and `--no-ri` options when installing gems was
removed in Ruby 2.6+ and replaced with the `--no-document` option:
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

Tested the `--do-document` option is available on Ruby 2.5 too.