### PR TITLE
pdksync - (IAC-1751) - Add Support for Rocky 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -56,6 +56,12 @@
         "16.04",
         "18.04"
       ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
(IAC-1751) - Add Support for Rocky 8
pdk version: `2.1.0` 
