### PR TITLE
pdksync - (GH-cat-11) Add Support for Ubuntu 22.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04"
+        "18.04",
+        "22.04"
       ]
     },
     {


### PR DESCRIPTION
(GH-cat-11) Add Support for Ubuntu 22.04
pdk version: `2.3.0` 
